### PR TITLE
fix(analytics): alinhar contratos da API com o pandora-front

### DIFF
--- a/analytics/serializers.py
+++ b/analytics/serializers.py
@@ -9,7 +9,7 @@ from fcs_parser.models import FileDataModel
 class DashboardSerializer(serializers.ModelSerializer):
     class Meta:
         model = DashboardModel
-        fields = ['id', 'name', 'dashboard_config', 'created_at']
+        fields = ['id', 'name', 'dashboard_config', 'created_at', 'file_data']
     def create(self, validated_data):
         name = validated_data.get('name')
         dashboard_instance, created = DashboardModel.objects.update_or_create(
@@ -64,13 +64,15 @@ class ListGateSerializer(serializers.ModelSerializer):
         queryset=FileDataModel.objects.all(),
         allow_null=True,
     )
-    parent = serializers.PrimaryKeyRelatedField(queryset=GateModel.objects.all(), allow_null=True, required=False)
+    parent_id = serializers.PrimaryKeyRelatedField(
+        source="parent", queryset=GateModel.objects.all(), allow_null=True, required=False
+    )
     analysis_result = AnalysisResultSerializer(read_only=True)
     depth = 1
     
     class Meta:
         model = GateModel
-        fields = ['id', 'created_at','parent', 'children', 'file_data', 'name', 'gate_coordinates', 'analysis_result']
+        fields = ['id', 'created_at', 'parent_id', 'children', 'file_data', 'name', 'gate_coordinates', 'analysis_result']
 
     @extend_schema_field(serializers.ListField(child=serializers.DictField()))
     def get_children(self, obj):

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -1,13 +1,13 @@
 from django.urls import path
 
 from .views import (
-    CreateListGateView,
+    CreateGateView,
     GetGateDataView,
 )
 
 app_name = "analytics"
 
 urlpatterns = [
-    path("gate", CreateListGateView.as_view()),
+    path("gate", CreateGateView.as_view()),
     path("gate/<int:gate_id>/list", GetGateDataView.as_view()),
 ]

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,64 +1,30 @@
 
 from django.shortcuts import get_object_or_404
-from fcs_parser.serializers import ListFileDataSerializer, ParamListDataSerializer
+from fcs_parser.serializers import ParamListDataSerializer
 from rest_framework import generics
 from analytics.models import GateModel
-from analytics.serializers import DashboardSerializer, GateSerializer, ListGateSerializer
-from fcs_parser.models import FileDataModel
-from utils.mixins import SerializerByMethodMixin
+from analytics.serializers import DashboardSerializer, GateSerializer
 from rest_framework.views import  Response, status
 import pandas as pd
 import json
 
 # Create your views here.
 
-class CreateListGateView(SerializerByMethodMixin, generics.ListCreateAPIView):
-    serializer_map = {"GET": ListGateSerializer, "POST": GateSerializer}
+class CreateGateView(generics.CreateAPIView):
+    serializer_class = GateSerializer
 
-    def get_queryset(self):
-        file_id = self.kwargs['file_id']
-        return GateModel.objects.filter(file_data_id=file_id)
-    
-    def get(self, request, *args, **kwargs):
-      file_id = self.kwargs['file_id']
-      
-      file_data = get_object_or_404(FileDataModel, pk=file_id)
-  
-      tree = {
-          "id": file_data.id,
-          "file_name": file_data.file_name,
-          "data_set": file_data.data_set,
-          "gates": [],
-      }
-
-      gates = self.get_queryset().values(
-          "id", "name", "parent_id", "gate_coordinates"
-      )
-
-      gate_map = {}
-      for gate in gates:
-          gate_map[gate["id"]] = {**gate, "children": []}
-
-      for gate in gates:
-          parent_id = gate["parent_id"]
-          if parent_id:
-              gate_map[parent_id]["children"].append(gate_map[gate["id"]])
-          else:
-              tree["gates"].append(gate_map[gate["id"]])
-    
-      return Response(tree, status=status.HTTP_200_OK)
     def post(self, request, *args, **kwargs):
         data = request.data.copy()
-        dashboard_data = data.pop('dashboard', None) 
-        
+        dashboard_data = data.pop('dashboard', None)
+
         dashboard_serializer = DashboardSerializer(data=dashboard_data)
         dashboard_serializer.is_valid(raise_exception=True)
 
-        dash_instance = dashboard_serializer.save()  
-        data['dashboard'] = dash_instance.id 
-        serializer = self.get_serializer(data=data) 
+        dash_instance = dashboard_serializer.save()
+        data['dashboard'] = dash_instance.id
+        serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
-        serializer.save() 
+        serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 


### PR DESCRIPTION
## Summary

Corrige 3 divergências de contrato entre o backend e o `pandora-front` (consumidor da API), encontradas ao comparar os tipos/chamadas do front com os serializers/rotas do back. Nenhuma rota muda; são ajustes de dados persistidos e de naming/limpeza.

### 1. `DashboardSerializer` não persistia `file_data`

O front envia `dashboard.file_data` no `POST /analytics/gate`, mas o serializer não tinha o campo, então era descartado silenciosamente — e o `unique_together = ('name', 'file_data')` do `DashboardModel` ficava sempre com `file_data=NULL`.

```diff
- fields = ['id', 'name', 'dashboard_config', 'created_at']
+ fields = ['id', 'name', 'dashboard_config', 'created_at', 'file_data']
```

### 2. `ListGateSerializer` agora expõe `parent_id` (não `parent`)

Havia inconsistência: `GateModel.build_tree()` (usado em `GET /experiment/list/data/:id`) retorna `parent_id`, mas `ListGateSerializer` (usado em `GET /experiment/file/:id/list` e `/analytics/gate/:id/list`) retornava `parent`. O front tipa `Gate.parent_id`. Padronizado em `parent_id`:

```python
parent_id = serializers.PrimaryKeyRelatedField(
    source="parent", queryset=GateModel.objects.all(), allow_null=True, required=False
)
```
`GateSerializer` (escrita, no create) continua aceitando `parent`, que é o que o front envia ao criar.

### 3. Remoção do GET inacessível em `CreateListGateView`

O método `get()` referenciava `self.kwargs['file_id']`, mas a rota `path("gate", ...)` não tem esse parâmetro → `KeyError`/500 se chamado. O front nunca chama esse GET (usa `GET /analytics/gate/:id/list` → `GetGateDataView`). A view foi reduzida a `CreateAPIView` (renomeada `CreateListGateView` → `CreateGateView`) e imports órfãos removidos.

## Verificação

- `python manage.py check` → sem issues
- `python manage.py spectacular` → 0 erros
- Shell: `ListGateSerializer().get_fields()` expõe `parent_id` com `source="parent"`; `DashboardSerializer` inclui `file_data`
- Obs.: o round-trip via banco com `TEST=1` (SQLite) não roda por incompatibilidade do `ArrayField` do Postgres com SQLite — não relacionado a estas mudanças.


Link to Devin session: https://app.devin.ai/sessions/7fc3d445976845799f115c62ec366eed
Requested by: @paulo-moro