### PR TITLE
feat(density): cutoff configurável no heatmap

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -104,6 +104,7 @@ class GateDensityView(APIView):
             OpenApiParameter(name="xscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
+            OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
         ],
         responses=inline_serializer(
             name="GateDensityResponse",
@@ -124,12 +125,16 @@ class GateDensityView(APIView):
         x_scale = request.query_params.get("xscale") or default_scale(x_param)
         y_scale = request.query_params.get("yscale") or default_scale(y_param)
         cofactor = float(request.query_params.get("cofactor", DEFAULT_COFACTOR))
+        try:
+            cutoff = max(int(request.query_params.get("cutoff", 0)), 0)
+        except (TypeError, ValueError):
+            cutoff = 0
 
         gate = get_object_or_404(GateModel, pk=gate_id)
 
         cache_key = density_cache_key(
             "gate", gate.file_data_id, gate_id, x_param, y_param, mode, bins, sample,
-            x_scale, y_scale, cofactor,
+            x_scale, y_scale, cofactor, cutoff,
         )
         cached = get_cached_density(cache_key)
         if cached is not None:
@@ -154,7 +159,7 @@ class GateDensityView(APIView):
         if mode == "scatter":
             result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor)
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor)
+            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff)
 
         if result is None:
             return Response(

--- a/fcs_parser/views.py
+++ b/fcs_parser/views.py
@@ -255,6 +255,7 @@ class FileDensityView(APIView):
             OpenApiParameter(name="xscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
+            OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
         ],
         responses=inline_serializer(
             name="FileDensityResponse",
@@ -275,10 +276,14 @@ class FileDensityView(APIView):
         x_scale = request.query_params.get("xscale") or default_scale(x_param)
         y_scale = request.query_params.get("yscale") or default_scale(y_param)
         cofactor = float(request.query_params.get("cofactor", DEFAULT_COFACTOR))
+        try:
+            cutoff = max(int(request.query_params.get("cutoff", 0)), 0)
+        except (TypeError, ValueError):
+            cutoff = 0
 
         cache_key = density_cache_key(
             "file", file_id, file_id, x_param, y_param, mode, bins, sample,
-            x_scale, y_scale, cofactor,
+            x_scale, y_scale, cofactor, cutoff,
         )
         cached = get_cached_density(cache_key)
         if cached is not None:
@@ -292,7 +297,7 @@ class FileDensityView(APIView):
         if mode == "scatter":
             result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor)
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor)
+            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff)
 
         if result is None:
             return Response(

--- a/utils/density.py
+++ b/utils/density.py
@@ -25,11 +25,12 @@ def invalidate_density(file_data_id):
 
 
 def density_cache_key(
-    scope, file_data_id, obj_id, x, y, mode, bins, sample, x_scale, y_scale, cofactor
+    scope, file_data_id, obj_id, x, y, mode, bins, sample, x_scale, y_scale,
+    cofactor, cutoff=0
 ) -> str:
     return (
         f"density:{scope}:{obj_id}:v{_version(file_data_id)}:{x}:{y}:{mode}:{bins}"
-        f":{sample}:{x_scale}:{y_scale}:{cofactor}"
+        f":{sample}:{x_scale}:{y_scale}:{cofactor}:{cutoff}"
     )
 
 
@@ -92,12 +93,18 @@ def compute_density(
     x_scale: str = "linear",
     y_scale: str = "linear",
     cofactor: float = DEFAULT_COFACTOR,
+    cutoff: int = 0,
 ):
     """Return a 2-D histogram dict ready to be sent as JSON.
 
     Os eixos sao transformados (biex/linear) ANTES do binning, para que as bins
     fiquem uniformes no espaco exibido. As bordas retornadas estao no espaco
     transformado; o front mapeia os ticks de volta para unidades reais.
+
+    Bins com contagem <= cutoff viram None (null no JSON) para que o front os
+    renderize transparentes em vez de pintados na cor mais fria do colormap.
+    Com cutoff=0 (default) apenas as bins vazias somem; valores maiores cortam
+    ruido/outliers de baixa densidade.
     """
     x_col = normalize_column_name(x_param)
     y_col = normalize_column_name(y_param)
@@ -120,13 +127,23 @@ def compute_density(
         xv, yv, bins=bins,
     )
 
+    counts = histogram.T.astype(int)
+    # Bins <= cutoff -> None (null) para o front renderizar transparente.
+    threshold = max(int(cutoff), 0)
+    masked = np.where(counts > threshold, counts, None)
+    histogram_json = [
+        [None if v is None else int(v) for v in row]
+        for row in masked.tolist()
+    ]
+
     return {
-        "histogram": histogram.T.astype(int).tolist(),
+        "histogram": histogram_json,
         "x_edges": np.round(x_edges, 4).tolist(),
         "y_edges": np.round(y_edges, 4).tolist(),
         "x_scale": x_scale,
         "y_scale": y_scale,
         "cofactor": cofactor,
+        "cutoff": threshold,
     }
 
 


### PR DESCRIPTION
## Summary
Os heatmaps ficavam com "fundo azul": bins vazios têm contagem `0` e o front renderiza com `colorscale: "Jet"`, que mapeia `0` → azul, pintando toda a área ao redor dos dados.

Esta PR adiciona um parâmetro de query `cutoff` (int, default `0`) às rotas de density (`FileDensityView` e `GateDensityView`). Em `compute_density`, bins com contagem `<= cutoff` passam a ser emitidos como `null` no JSON (em vez de `0`), e o Plotly renderiza células `null` como **transparentes**:

- `cutoff=0` (default): some o fundo azul automaticamente (bins vazios viram transparentes);
- `cutoff>0`: corta ruído/outliers de baixa densidade, ajustável pelo dash no front.

```python
counts = histogram.T.astype(int)
threshold = max(int(cutoff), 0)
masked = np.where(counts > threshold, counts, None)   # bins <= cutoff -> None
histogram_json = [[None if v is None else int(v) for v in row] for row in masked.tolist()]
# resposta inclui "cutoff": threshold
```

`density_cache_key` passa a incluir `cutoff` para não misturar cache entre cutoffs diferentes. O parâmetro é parseado de forma defensiva (valores inválidos/negativos → `0`).

O `mode=scatter` não é afetado. PR correspondente no `pandora-front` adiciona o controle de cutoff no dash e envia `&cutoff=N`.


Link to Devin session: https://app.devin.ai/sessions/cabd69b982ce4634971a6ad31003632f
Requested by: @paulo-moro