### PR TITLE
feat(density): aceitar limites de eixo (xmin/xmax/ymin/ymax) na API de densidade

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -14,6 +14,7 @@ from utils.density import (
     density_cache_key,
     get_cached_density,
     normalize_columns,
+    parse_range,
     set_cached_density,
     subsample_scatter,
 )
@@ -105,6 +106,10 @@ class GateDensityView(APIView):
             OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
             OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
+            OpenApiParameter(name="xmin", type=float, required=False, description="Lower bound for X axis (raw value)"),
+            OpenApiParameter(name="xmax", type=float, required=False, description="Upper bound for X axis (raw value)"),
+            OpenApiParameter(name="ymin", type=float, required=False, description="Lower bound for Y axis (raw value)"),
+            OpenApiParameter(name="ymax", type=float, required=False, description="Upper bound for Y axis (raw value)"),
         ],
         responses=inline_serializer(
             name="GateDensityResponse",
@@ -129,6 +134,8 @@ class GateDensityView(APIView):
             cutoff = max(int(request.query_params.get("cutoff", 0)), 0)
         except (TypeError, ValueError):
             cutoff = 0
+        x_range = parse_range(request.query_params, "xmin", "xmax")
+        y_range = parse_range(request.query_params, "ymin", "ymax")
 
         gate = get_object_or_404(GateModel, pk=gate_id)
 
@@ -136,6 +143,10 @@ class GateDensityView(APIView):
             "gate", gate.file_data_id, gate_id, x_param, y_param, mode, bins, sample,
             x_scale, y_scale, cofactor, cutoff,
         )
+        if x_range:
+            cache_key += f":xr{x_range[0]}:{x_range[1]}"
+        if y_range:
+            cache_key += f":yr{y_range[0]}:{y_range[1]}"
         cached = get_cached_density(cache_key)
         if cached is not None:
             return Response(cached, status=status.HTTP_200_OK)
@@ -157,9 +168,9 @@ class GateDensityView(APIView):
         base = {"mode": mode, "total_events": len(dataset), "x_label": x_param, "y_label": y_param}
 
         if mode == "scatter":
-            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor)
+            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff)
+            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
 
         if result is None:
             return Response(

--- a/fcs_parser/views.py
+++ b/fcs_parser/views.py
@@ -22,6 +22,7 @@ from utils.density import (
     get_cached_density,
     invalidate_density,
     normalize_columns,
+    parse_range,
     set_cached_density,
     subsample_scatter,
 )
@@ -256,6 +257,10 @@ class FileDensityView(APIView):
             OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
             OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
             OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
+            OpenApiParameter(name="xmin", type=float, required=False, description="Lower bound for X axis (raw value)"),
+            OpenApiParameter(name="xmax", type=float, required=False, description="Upper bound for X axis (raw value)"),
+            OpenApiParameter(name="ymin", type=float, required=False, description="Lower bound for Y axis (raw value)"),
+            OpenApiParameter(name="ymax", type=float, required=False, description="Upper bound for Y axis (raw value)"),
         ],
         responses=inline_serializer(
             name="FileDensityResponse",
@@ -280,11 +285,17 @@ class FileDensityView(APIView):
             cutoff = max(int(request.query_params.get("cutoff", 0)), 0)
         except (TypeError, ValueError):
             cutoff = 0
+        x_range = parse_range(request.query_params, "xmin", "xmax")
+        y_range = parse_range(request.query_params, "ymin", "ymax")
 
         cache_key = density_cache_key(
             "file", file_id, file_id, x_param, y_param, mode, bins, sample,
             x_scale, y_scale, cofactor, cutoff,
         )
+        if x_range:
+            cache_key += f":xr{x_range[0]}:{x_range[1]}"
+        if y_range:
+            cache_key += f":yr{y_range[0]}:{y_range[1]}"
         cached = get_cached_density(cache_key)
         if cached is not None:
             return Response(cached, status=status.HTTP_200_OK)
@@ -295,9 +306,9 @@ class FileDensityView(APIView):
         base = {"mode": mode, "total_events": len(dataset), "x_label": x_param, "y_label": y_param}
 
         if mode == "scatter":
-            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor)
+            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff)
+            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
 
         if result is None:
             return Response(

--- a/utils/density.py
+++ b/utils/density.py
@@ -57,6 +57,17 @@ def set_cached_density(key, value):
 DEFAULT_COFACTOR = 150.0
 
 
+def parse_range(query_params, min_key: str, max_key: str):
+    """Return (min, max) tuple from query params, or None if neither is set."""
+    raw_min = query_params.get(min_key)
+    raw_max = query_params.get(max_key)
+    if raw_min is None and raw_max is None:
+        return None
+    lo = float(raw_min) if raw_min is not None else -float("inf")
+    hi = float(raw_max) if raw_max is not None else float("inf")
+    return (lo, hi)
+
+
 def normalize_column_name(name: str) -> str:
     return name.lower().replace(" ", "").replace("-", "_")
 
@@ -94,6 +105,8 @@ def compute_density(
     y_scale: str = "linear",
     cofactor: float = DEFAULT_COFACTOR,
     cutoff: int = 0,
+    x_range: tuple | None = None,
+    y_range: tuple | None = None,
 ):
     """Return a 2-D histogram dict ready to be sent as JSON.
 
@@ -123,8 +136,24 @@ def compute_density(
     xv = apply_scale(x.values, x_scale, cofactor)
     yv = apply_scale(y.values, y_scale, cofactor)
 
+    hist_range = None
+    if x_range or y_range:
+        xr = (
+            [apply_scale(np.array([x_range[0]]), x_scale, cofactor)[0],
+             apply_scale(np.array([x_range[1]]), x_scale, cofactor)[0]]
+            if x_range
+            else [float(np.min(xv)), float(np.max(xv))]
+        )
+        yr = (
+            [apply_scale(np.array([y_range[0]]), y_scale, cofactor)[0],
+             apply_scale(np.array([y_range[1]]), y_scale, cofactor)[0]]
+            if y_range
+            else [float(np.min(yv)), float(np.max(yv))]
+        )
+        hist_range = [xr, yr]
+
     histogram, x_edges, y_edges = np.histogram2d(
-        xv, yv, bins=bins,
+        xv, yv, bins=bins, range=hist_range,
     )
 
     counts = histogram.T.astype(int)
@@ -219,6 +248,8 @@ def subsample_scatter(
     x_scale: str = "linear",
     y_scale: str = "linear",
     cofactor: float = DEFAULT_COFACTOR,
+    x_range: tuple | None = None,
+    y_range: tuple | None = None,
 ):
     """Return a subsampled scatter dict ready to be sent as JSON (espaco exibido)."""
     x_col = normalize_column_name(x_param)
@@ -228,6 +259,11 @@ def subsample_scatter(
         return None
 
     subset = df[[x_col, y_col]].dropna()
+
+    if x_range:
+        subset = subset[(subset[x_col] >= x_range[0]) & (subset[x_col] <= x_range[1])]
+    if y_range:
+        subset = subset[(subset[y_col] >= y_range[0]) & (subset[y_col] <= y_range[1])]
 
     if len(subset) > sample:
         subset = subset.sample(n=sample, random_state=42)


### PR DESCRIPTION
## Summary

Adiciona suporte a limites de eixo opcionais (`xmin`, `xmax`, `ymin`, `ymax`) nas views de densidade, permitindo que o front controle o range do gráfico sem arrastar/zoom.

### Mudanças na API
Ambas `FileDensityView` e `GateDensityView` aceitam novos query params `xmin/xmax/ymin/ymax` (valores em espaço bruto/linear). O schema OpenAPI foi atualizado.

### `compute_density` — range no histogram2d
Quando limites fornecidos, converte-os para espaço transformado (biex) via `apply_scale` e passa como `range=[[xr_lo, xr_hi], [yr_lo, yr_hi]]` ao `np.histogram2d`. Melhora resolução dos bins no range visível.

### `subsample_scatter` — filtragem por range
Pontos fora do range são descartados antes do subsampling, evitando amostrar dados irrelevantes.

### `parse_range` helper
```python
def parse_range(query_params, min_key, max_key) -> tuple | None
```
Retorna `(lo, hi)` ou `None`. Limites omitidos usam `±inf`.

PR complementar no frontend: Laboratorio-de-Analise-de-Dados/pandora-front (branch `devin/1780918501-plotly-improvements`).

Link to Devin session: https://app.devin.ai/sessions/781576e75a444d3885bc5c0ee45adf35
Requested by: @paulo-moro