### PR TITLE
feat(density): adicionar modo histograma (1D)

### DIFF
--- a/analytics/views.py
+++ b/analytics/views.py
@@ -10,6 +10,7 @@ from utils.density import (
     DEFAULT_COFACTOR,
     apply_gate_filter,
     compute_density,
+    compute_histogram,
     default_scale,
     density_cache_key,
     get_cached_density,
@@ -169,6 +170,8 @@ class GateDensityView(APIView):
 
         if mode == "scatter":
             result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
+        elif mode == "histogram":
+            result = compute_histogram(dataset, x_param, bins, x_scale, cofactor, x_range)
         else:
             result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
 

--- a/fcs_parser/views.py
+++ b/fcs_parser/views.py
@@ -17,6 +17,7 @@ from rest_framework.views import APIView
 from utils.density import (
     DEFAULT_COFACTOR,
     compute_density,
+    compute_histogram,
     default_scale,
     density_cache_key,
     get_cached_density,
@@ -307,6 +308,8 @@ class FileDensityView(APIView):
 
         if mode == "scatter":
             result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
+        elif mode == "histogram":
+            result = compute_histogram(dataset, x_param, bins, x_scale, cofactor, x_range)
         else:
             result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
 

--- a/utils/density.py
+++ b/utils/density.py
@@ -176,6 +176,51 @@ def compute_density(
     }
 
 
+def compute_histogram(
+    df: pd.DataFrame,
+    x_param: str,
+    bins: int = 256,
+    x_scale: str = "linear",
+    cofactor: float = DEFAULT_COFACTOR,
+    x_range: tuple | None = None,
+):
+    """Return a 1-D histogram dict ready to be sent as JSON.
+
+    Histogram unidimensional (distribuicao de um unico parametro). Os bins
+    ficam uniformes no espaco transformado (biex/linear).
+    """
+    x_col = normalize_column_name(x_param)
+
+    if x_col not in df.columns:
+        return None
+
+    x = pd.to_numeric(df[x_col], errors="coerce").dropna()
+
+    if x_range:
+        x = x[(x >= x_range[0]) & (x <= x_range[1])]
+
+    if len(x) == 0:
+        return None
+
+    xv = apply_scale(x.values, x_scale, cofactor)
+
+    hist_range = None
+    if x_range:
+        hist_range = (
+            float(apply_scale(np.array([x_range[0]]), x_scale, cofactor)[0]),
+            float(apply_scale(np.array([x_range[1]]), x_scale, cofactor)[0]),
+        )
+
+    counts, edges = np.histogram(xv, bins=bins, range=hist_range)
+
+    return {
+        "counts": counts.tolist(),
+        "edges": np.round(edges, 4).tolist(),
+        "x_scale": x_scale,
+        "cofactor": cofactor,
+    }
+
+
 def _points_in_polygon(xs, ys, vertices) -> np.ndarray:
     """Teste vetorizado de ponto-em-poligono (ray casting). Coordenadas e
     vertices no MESMO espaco (cru). Retorna mascara booleana alinhada a xs/ys."""


### PR DESCRIPTION
## Summary

Adiciona `mode=histogram` na API de densidade — histograma 1D de um único parâmetro.

### Nova função `compute_histogram()` em `utils/density.py`
```python
def compute_histogram(df, x_param, bins=256, x_scale="linear", cofactor=150, x_range=None):
    # Filtra por x_range, aplica escala, np.histogram
    return {"counts": [...], "edges": [...], "x_scale": ..., "cofactor": ...}
```

### Views atualizadas
Tanto `FileDensityView` quanto `GateDensityView` agora roteiam para `compute_histogram` quando `mode=histogram`:
```python
elif mode == "histogram":
    result = compute_histogram(dataset, x_param, bins, x_scale, cofactor, x_range)
```

- 256 bins por default
- Respeita `xmin/xmax` (filtra antes, passa `range` ao `np.histogram`)
- Respeita `xscale` (biex/linear)
- Cacheado normalmente via `density_cache_key`

PR complementar no frontend: pandora-front (branch `devin/1780967466-histogram-mode`).

Link to Devin session: https://app.devin.ai/sessions/781576e75a444d3885bc5c0ee45adf35
Requested by: @paulo-moro