### PR TITLE
feat(analytics): tree-level gate constraint + rename/delete endpoint

### DIFF
--- a/analytics/migrations/0007_remove_unique_together_add_tree_constraints.py
+++ b/analytics/migrations/0007_remove_unique_together_add_tree_constraints.py
@@ -1,0 +1,31 @@
+import django.db.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analytics", "0006_alter_analysisresult_gate"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="gatemodel",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="gatemodel",
+            constraint=models.UniqueConstraint(
+                fields=["name", "parent"],
+                name="unique_gate_name_per_parent",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="gatemodel",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(parent__isnull=True),
+                fields=["name", "file_data"],
+                name="unique_gate_name_root_level",
+            ),
+        ),
+    ]

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -7,7 +7,17 @@ class GateModel(models.Model):
 
     class Meta:
         db_table = "gate"
-        unique_together = ('name', 'file_data')
+        constraints = [
+            models.UniqueConstraint(
+                fields=['name', 'parent'],
+                name='unique_gate_name_per_parent',
+            ),
+            models.UniqueConstraint(
+                fields=['name', 'file_data'],
+                condition=models.Q(parent__isnull=True),
+                name='unique_gate_name_root_level',
+            ),
+        ]
 
     file_data = models.ForeignKey(
         FileDataModel, related_name="gates", on_delete=models.CASCADE, null=True

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -37,12 +37,26 @@ class GateModel(models.Model):
         """
         Constrói uma estrutura de árvore de gates a partir de dados de um arquivo.
         """
-        gates = cls.objects.filter(file_data_id=file_data_id).values(
+        from analytics.models import AnalysisResult
+
+        gates = list(cls.objects.filter(file_data_id=file_data_id).values(
             "id", "name", "parent_id", "gate_coordinates"
-        )
+        ))
+
+        # Busca analysis_result para todos os gates deste arquivo
+        gate_ids = [g["id"] for g in gates]
+        analysis_map = {}
+        for ar in AnalysisResult.objects.filter(gate_id__in=gate_ids).values("gate_id", "analysis_result"):
+            analysis_map[ar["gate_id"]] = ar["analysis_result"]
 
         # Cria um mapa de gates, preparando cada um para receber filhos
-        gate_map = {gate["id"]: {**gate, "children": []} for gate in gates}
+        gate_map = {}
+        for gate in gates:
+            entry = {**gate, "children": []}
+            ar = analysis_map.get(gate["id"])
+            if ar:
+                entry["analysis_result"] = {"analysis_result": ar}
+            gate_map[gate["id"]] = entry
         roots = []
 
         # Percorre todos os gates para construir a hierarquia

--- a/analytics/serializers.py
+++ b/analytics/serializers.py
@@ -10,12 +10,14 @@ class DashboardSerializer(serializers.ModelSerializer):
     class Meta:
         model = DashboardModel
         fields = ['id', 'name', 'dashboard_config', 'created_at', 'file_data']
+        validators = []  # disable auto UniqueTogetherValidator; handled in create()
+
     def create(self, validated_data):
-        name = validated_data.get('name')
         dashboard_instance, created = DashboardModel.objects.update_or_create(
-            **validated_data
+            name=validated_data['name'],
+            file_data=validated_data['file_data'],
+            defaults={'dashboard_config': validated_data.get('dashboard_config', {})},
         )
-        print(f"Dashboard '{dashboard_instance.name}' {'criado' if created else 'atualizado'} via Serializer.")
         return dashboard_instance
         
 class GateSerializer(serializers.ModelSerializer):

--- a/analytics/serializers.py
+++ b/analytics/serializers.py
@@ -28,7 +28,7 @@ class GateSerializer(serializers.ModelSerializer):
         required=True, 
         allow_null=False
     ) 
-    parent = serializers.PrimaryKeyRelatedField(queryset=GateModel.objects.all(), allow_null=True, required=False)
+    parent = serializers.PrimaryKeyRelatedField(queryset=GateModel.objects.all(), allow_null=True, required=False, default=None)
     class Meta: 
         model = GateModel
         fields = [

--- a/analytics/urls.py
+++ b/analytics/urls.py
@@ -4,12 +4,14 @@ from .views import (
     CreateGateView,
     GateDensityView,
     GetGateDataView,
+    UpdateGateView,
 )
 
 app_name = "analytics"
 
 urlpatterns = [
     path("gate", CreateGateView.as_view()),
+    path("gate/<int:gate_id>", UpdateGateView.as_view()),
     path("gate/<int:gate_id>/list", GetGateDataView.as_view()),
     path("gate/<int:gate_id>/density", GateDensityView.as_view()),
 ]

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -42,6 +42,26 @@ class CreateGateView(generics.CreateAPIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
+class UpdateGateView(generics.RetrieveUpdateDestroyAPIView):
+    """PATCH/DELETE /analytics/gate/<gate_id> — rename or delete a gate."""
+    serializer_class = GateSerializer
+    lookup_url_kwarg = "gate_id"
+    queryset = GateModel.objects.all()
+
+    def get_object(self):
+        gate_id = self.kwargs.get(self.lookup_url_kwarg)
+        return get_object_or_404(GateModel, pk=gate_id)
+
+    def patch(self, request, *args, **kwargs):
+        gate = self.get_object()
+        new_name = request.data.get("name")
+        if new_name is not None:
+            gate.name = new_name
+            gate.save(update_fields=["name"])
+        serializer = self.get_serializer(gate)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
 class GetGateDataView(generics.ListAPIView):
     serializer_class = GateSerializer
     lookup_url_kwarg = "gate_id"

--- a/utils/density.py
+++ b/utils/density.py
@@ -243,7 +243,7 @@ def _points_in_polygon(xs, ys, vertices) -> np.ndarray:
 
 
 def apply_gate_filter(dataset: pd.DataFrame, gate) -> pd.DataFrame:
-    """Apply a single gate's filter (rectangle or polygon) to a DataFrame.
+    """Apply a single gate's filter (rectangle, polygon, interval or quadrant) to a DataFrame.
 
     Colunas ja normalizadas; coordenadas do gate sempre em espaco cru (linear),
     independente da escala usada para exibir o grafico.
@@ -258,11 +258,47 @@ def apply_gate_filter(dataset: pd.DataFrame, gate) -> pd.DataFrame:
         x_label = normalize_column_name(config.get("x_axis_label", x_label))
         y_label = normalize_column_name(config.get("y_axis_label", y_label))
 
+    gate_type = gate_coords.get("type")
+
+    # Gate de intervalo (1D, apenas eixo X — histograma).
+    if gate_type == "interval":
+        x_col = normalize_column_name(gate_coords.get("x_axis", "")) or x_label
+        if x_col not in dataset.columns:
+            return dataset
+        start_x = gate_coords.get("startX")
+        end_x = gate_coords.get("endX")
+        if start_x is not None and end_x is not None:
+            return dataset[
+                (dataset[x_col] >= start_x) & (dataset[x_col] <= end_x)
+            ]
+        return dataset
+
+    # Gate de quadrante: filtra um dos 4 quadrantes a partir do centro da cruz.
+    if gate_type == "quadrant":
+        x_col = normalize_column_name(gate_coords.get("x_axis", "")) or x_label
+        y_col = normalize_column_name(gate_coords.get("y_axis", "")) or y_label
+        if x_col not in dataset.columns or y_col not in dataset.columns:
+            return dataset
+        cx = gate_coords.get("center_x")
+        cy = gate_coords.get("center_y")
+        quadrant = gate_coords.get("quadrant")
+        if cx is None or cy is None or quadrant is None:
+            return dataset
+        if quadrant == "Q1":  # X+ Y+
+            return dataset[(dataset[x_col] >= cx) & (dataset[y_col] >= cy)]
+        elif quadrant == "Q2":  # X- Y+
+            return dataset[(dataset[x_col] < cx) & (dataset[y_col] >= cy)]
+        elif quadrant == "Q3":  # X- Y-
+            return dataset[(dataset[x_col] < cx) & (dataset[y_col] < cy)]
+        elif quadrant == "Q4":  # X+ Y-
+            return dataset[(dataset[x_col] >= cx) & (dataset[y_col] < cy)]
+        return dataset
+
     if x_label not in dataset.columns or y_label not in dataset.columns:
         return dataset
 
     # Gate poligonal: lista de vertices [[x, y], ...].
-    if gate_coords.get("type") == "polygon":
+    if gate_type == "polygon":
         vertices = gate_coords.get("vertices") or []
         if len(vertices) >= 3:
             mask = _points_in_polygon(


### PR DESCRIPTION
## Summary

**Gate name constraint** (relaxed from global to tree-level):
- Replaces `unique_together = ('name', 'file_data')` with two `UniqueConstraint`:
  - `(name, parent)` — siblings under same parent must be unique.
  - `(name, file_data)` with `condition=Q(parent__isnull=True)` — root gates unique per file.
- Gates with different parents or in different files can now share names (e.g. passing gates between files).
- Migration `0007` handles the transition.

**New endpoint** `PATCH/DELETE /analytics/gate/<gate_id>`:
- `UpdateGateView(RetrieveUpdateDestroyAPIView)` handles rename and delete.
- `PATCH {name: "new name"}` → renames the gate.
- `DELETE` → removes the gate (previously had no dedicated endpoint).

**Gate filter support for interval + quadrant types** (from previous commit):
- `apply_gate_filter()` handles `type == "interval"` (X range only) and `type == "quadrant"` (Q1–Q4 based on center point).

Link to Devin session: https://app.devin.ai/sessions/220490f03a6846d5a6927e572c9e88d3
Requested by: @paulo-moro