### PR TITLE
refactor: ZIP como fonte da verdade, services unificados, tipagem e logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ análise.
 ## Sumário
 
 - [Stack](#stack)
-- [Documentação interativa da API (Swagger / Redoc)](#documentação-interativa-da-api-swagger--redoc)
 - [Como rodar o projeto](#como-rodar-o-projeto)
-  - [Com Docker (recomendado)](#com-docker-recomendado)
-  - [Localmente sem Docker](#localmente-sem-docker)
 - [Variáveis de ambiente](#variáveis-de-ambiente)
+- [Arquitetura](#arquitetura)
+- [Guia de contribuição e decisões de código](#guia-de-contribuição-e-decisões-de-código)
+- [Documentação interativa da API (Swagger / Redoc)](#documentação-interativa-da-api-swagger--redoc)
 - [Visão geral das rotas](#visão-geral-das-rotas)
 - [Estrutura do projeto](#estrutura-do-projeto)
 - [Deploy](#deploy)
@@ -30,31 +30,10 @@ análise.
 - **JWT** (`djangorestframework-simplejwt`) para autenticação
 - **PostgreSQL** como banco de dados
 - **Celery** + **Redis** para processamento assíncrono dos arquivos FCS
+- **Pandas** + **PyArrow** para manipulação de dados e cache em Parquet
 - **drf-spectacular** para geração automática da documentação OpenAPI
 - **Docker** / **docker-compose** para ambiente local e produção
-
----
-
-## Documentação interativa da API (Swagger / Redoc)
-
-A documentação da API é **gerada automaticamente** a partir do código (rotas,
-serializers e respostas), então fica sempre em sincronia com a implementação.
-Com o servidor rodando, acesse:
-
-| Recurso | URL | Descrição |
-| --- | --- | --- |
-| **Swagger UI** | `/api/docs/` | Documentação interativa — permite testar as rotas e ver request/response no navegador |
-| **Redoc** | `/api/redoc/` | Documentação em formato de leitura |
-| **Schema OpenAPI** | `/api/schema/` | Arquivo OpenAPI 3 (YAML) bruto |
-
-Para autenticar no Swagger UI: faça login em `POST /accounts/login/`, copie o
-`access` token retornado, clique em **Authorize** e informe `Bearer <access>`.
-
-Você também pode exportar o schema como arquivo:
-
-```bash
-python manage.py spectacular --file schema.yml
-```
+- **Black** para formatação de código
 
 ---
 
@@ -68,15 +47,18 @@ Sobe a API, o banco PostgreSQL, o Redis e o worker do Celery de uma vez.
 # 1. crie a rede externa usada pelo compose (apenas na primeira vez)
 docker network create pandora_net
 
-# 2. suba os serviços
+# 2. suba os serviços (já roda migrations automaticamente)
 docker compose up --build
 ```
 
 A API ficará disponível em `http://localhost:8085` (mapeada para a porta 8000 do
 container). A porta pode ser alterada com a variável `WEB_PORT`.
 
-> Os valores de banco/redis para o ambiente de desenvolvimento já vêm definidos
-> no `docker-compose.yml`.
+> O `docker-compose.yml` já executa `makemigrations && migrate` antes de subir
+> o servidor. Se precisar forçar uma migration manualmente:
+> ```bash
+> docker compose exec web python manage.py migrate
+> ```
 
 ### Localmente sem Docker
 
@@ -125,9 +107,256 @@ ambiente). As principais:
 | `REDIS_HOST` | Host do Redis (padrão `redis`) |
 | `REDIS_PORT` | Porta do Redis (padrão `6379`) |
 | `MEDIA_ROOT` | Diretório onde os uploads são salvos |
+| `PARQUET_MAX_IDLE_DAYS` | Dias sem acesso antes de limpar Parquet frio (padrão `7`) |
 | `EMAIL_HOST_USER` | Usuário SMTP (envio de convites por e-mail) |
 | `EMAIL_HOST_PASSWORD` | Senha SMTP |
 | `TEST` | Se definida, usa SQLite em vez do PostgreSQL (útil para testes) |
+
+---
+
+## Arquitetura
+
+### Visão geral
+
+O backend é organizado em 3 Django apps com responsabilidades claras:
+
+```
+accounts/       Autenticação, usuários, organizações, RBAC
+fcs_parser/     Upload, processamento e storage de dados FCS
+analytics/      Gates, análises estatísticas, density/heatmaps
+```
+
+Lógica pesada (parsing de FCS, recálculo de gates) roda em tasks **Celery**
+assíncronas. O Redis serve tanto como broker do Celery quanto como cache de
+density/heatmap.
+
+### Modelo de dados principal
+
+```
+Organization (1) ──> (N) ExperimentModel
+                              │
+                              ├── zip_path (fonte da verdade)
+                              ├── values (canais encontrados)
+                              │
+                              └── (1) FileModel (ZIP original)
+                                        │
+                                        └── (N) FileDataModel (um por .fcs)
+                                                   │
+                                                   ├── parquet_path (cache L2)
+                                                   ├── headers (metadados FCS)
+                                                   │
+                                                   └── (N) GateModel
+                                                              │
+                                                              ├── gate_coordinates
+                                                              ├── parent (hierarquia)
+                                                              └── (1) AnalysisResult
+```
+
+### Storage: ZIP como fonte da verdade
+
+O sistema usa uma arquitetura de cache em camadas onde o **ZIP original do
+upload é a fonte da verdade imutável**:
+
+```
+L0  ZIP (MEDIA_ROOT/{id}.zip)     ← fonte da verdade, nunca deletado
+L1  .fcs extraídos (efêmeros)     ← extraídos sob demanda, removidos após uso
+L2  Parquet (MEDIA_ROOT/parquet/) ← cache morno, regenerável do ZIP
+L3  Redis                         ← cache quente (density, heatmaps), TTL deslizante
+```
+
+**Fluxo de leitura** (`FileDataModel.get_dataframe()`):
+1. Tenta Parquet no disco (L2)
+2. Se expirou: extrai o `.fcs` específico do ZIP (L0), reparseia, regenera Parquet
+3. Fallback legado: `fcs_path` direto (dados pré-migração)
+4. Último recurso: `data_set` JSON no banco (dados muito antigos)
+
+**Fluxo de upload** (chunked):
+```
+Frontend                         Backend
+   │                                │
+   ├── POST /experiment/init/  ──>  │  Cria ExperimentModel
+   │                                │
+   ├── POST /upload-chunk/ (N×) ──> │  Salva chunks em MEDIA_ROOT/chunks/
+   │                                │
+   └── POST /complete/  ────────>   │  assemble_chunks() → ZIP
+                                    │  Cria FileModel
+                                    │  Dispara process_experiment_files_task
+                                    │
+                                    └── (Celery) process_experiment_zip()
+                                         │  Extrai ZIP → /fcs_files/{id}/
+                                         │  Para cada .fcs:
+                                         │    parse → FCSResult
+                                         │    cria FileDataModel + Parquet
+                                         │  Salva zip_path no ExperimentModel
+                                         └── Remove /fcs_files/{id}/ (efêmero)
+```
+
+### Camada de services
+
+A lógica de negócio vive em `fcs_parser/services/`:
+
+| Service | Responsabilidade |
+| --- | --- |
+| `process_fcs.py` | Parsing de um `.fcs` → `FCSResult` (dataclass tipada) |
+| `process_experiment_file.py` | Pipeline completo: chunks → ZIP → parse → FileData + Parquet |
+| `decompressor.py` | Extração de arquivos comprimidos |
+| `header_parser.py` | Serialização de headers FCS |
+
+**Regra**: views são finas (recebem request → delegam ao service → retornam
+response). Toda lógica de negócio, I/O e manipulação de dados fica nos services.
+
+### Gates e análise hierárquica
+
+Gates seguem uma estrutura de árvore (pai → filhos). O cálculo de métricas
+percorre toda a cadeia hierárquica do root até o gate alvo, aplicando filtros
+sequencialmente — mesmo padrão do FlowJo/Cytobank:
+
+```
+Root Gate (file_data)
+  └── Gate A (polígono)
+        └── Gate B (retângulo)
+              └── Gate C (polígono)
+```
+
+Para calcular métricas do Gate C: aplica filtro A → B → C sobre o dataset
+original. Métricas calculadas: count, %Parent, %Total, MFI por canal, CV.
+
+### Tasks Celery
+
+| Task | Frequência | Descrição |
+| --- | --- | --- |
+| `process_experiment_files_task` | Sob demanda | Processa ZIP de upload → FileData + Parquet |
+| `recompute_file_data_task` | Sob demanda | Regenera Parquet de um FileData a partir do ZIP |
+| `recalculate_gate_analysis_task` | Sob demanda | Recalcula métricas de um gate |
+| `cleanup_cold_parquet_task` | Semanal (dom 3h) | Remove Parquets órfãos e frios (>7d sem acesso) |
+| `cleanup_ephemeral_fcs_task` | Semanal (dom 4h) | Remove diretórios de extração abandonados |
+
+---
+
+## Guia de contribuição e decisões de código
+
+### Regras para abrir um PR
+
+1. **Formate com Black** antes de commitar:
+   ```bash
+   black .
+   ```
+
+2. **Não quebre a API existente** — endpoints e formatos de resposta devem
+   manter compatibilidade. Se precisar mudar, coordene com o front.
+
+3. **Não altere URLs sem alinhamento** — as rotas atuais estão acopladas ao
+   front. Mudanças de URL requerem PR coordenado.
+
+4. **Inclua migrations** — se mexeu em models, gere a migration:
+   ```bash
+   python manage.py makemigrations
+   ```
+   Confira se a migration gerada faz sentido e comite junto.
+
+5. **Não comite secrets** — nada de `.env`, tokens ou senhas no código.
+   Use variáveis de ambiente.
+
+6. **Teste a cascata de dados** — se mexeu no fluxo de
+   processamento/storage, garanta que o pipeline upload → process → analyze
+   funciona end-to-end.
+
+### Onde colocar código novo
+
+| Tipo de código | Onde vai |
+| --- | --- |
+| Lógica de negócio (parsing, processamento, cálculos) | `app/services/` |
+| Receber request e retornar response | `app/views.py` |
+| Definição de tabelas/campos | `app/models.py` |
+| Validação de input da API | `app/serializers.py` |
+| Processamento pesado/assíncrono | `app/tasks.py` (Celery) |
+| Helpers reutilizáveis entre apps | `utils/` |
+
+### Convenções de código
+
+- **Views são finas**: recebem request, delegam a um service, retornam
+  response. Se a view tem mais de ~15 linhas de lógica, extraia para um
+  service.
+
+- **Services retornam dataclasses tipadas**, nunca tuplas/listas genéricas
+  ou mixed types (e.g. `list | str`). Erros são exceções, não valores de
+  retorno.
+
+- **Logging, não print**: use `logger = logging.getLogger(__name__)` em todo
+  módulo. Nunca `print()` — logs estruturados permitem filtrar por nível e
+  módulo.
+
+- **`save(update_fields=[...])`**: sempre especifique os campos ao salvar
+  parcialmente. Evita race conditions e deixa claro o que mudou.
+
+- **Normalize colunas com o helper**: use `normalize_columns()` de
+  `utils/density.py` em vez de repetir `.str.replace().str.lower()` manual.
+
+- **Models devem ter `__str__`**: facilita debug no admin e nos logs.
+
+### Decisões arquiteturais
+
+Ao implementar algo novo, considere:
+
+1. **ZIP é a fonte da verdade** — nunca delete o ZIP. Todo dado derivado
+   (Parquet, .fcs extraído, JSON) é cache/efêmero e deve ser regenerável.
+
+2. **Cache é descartável** — Parquet, Redis, .fcs extraído podem ser
+   limpos sem perda. O código deve sempre ter um fallback para reconstruir
+   a partir do ZIP.
+
+3. **Processamento pesado vai pro Celery** — se a operação pode demorar
+   mais que ~2s (parsing FCS, recálculo de gates, density), faça uma task.
+   Views devem retornar `202 Accepted` e o front monitora o status.
+
+4. **Hierarquia de gates é uma árvore** — qualquer cálculo sobre um gate
+   precisa percorrer toda a cadeia de pais. Nunca calcule métricas de um
+   gate filho sem aplicar os filtros dos pais primeiro.
+
+5. **Backward compatibility** — ao mudar modelos ou fluxos, mantenha
+   fallback para dados antigos. Exemplo: `get_dataframe()` tem 4 níveis
+   de fallback justamente pra não quebrar dados pré-migração.
+
+6. **Uma única implementação por pipeline** — se a mesma lógica é usada
+   em task + view + outro lugar, extraia pra um service. Nunca duplique
+   pipelines de dados.
+
+7. **Permissões vêm depois** — a infraestrutura RBAC existe em `accounts/`
+   mas ainda não está aplicada nas views de `fcs_parser` e `analytics`.
+   Isso será feito no final.
+
+### O que NÃO fazer
+
+- Não crie endpoints REST fora do padrão sem motivo (evite `/list/data/`,
+  prefira coleções aninhadas: `/experiments/{id}/files/`)
+- Não use `isinstance(result, str)` como controle de fluxo — use exceções
+- Não salve dados permanentes em `/tmp` — use `MEDIA_ROOT`
+- Não delete o ZIP após extração — ele é a fonte da verdade
+- Não ignore erros silenciosamente — logue com nível WARNING ou ERROR
+- Não use `Any` ou acesso dinâmico de atributos (`getattr` pra campos conhecidos)
+
+---
+
+## Documentação interativa da API (Swagger / Redoc)
+
+A documentação da API é **gerada automaticamente** a partir do código (rotas,
+serializers e respostas), então fica sempre em sincronia com a implementação.
+Com o servidor rodando, acesse:
+
+| Recurso | URL | Descrição |
+| --- | --- | --- |
+| **Swagger UI** | `/api/docs/` | Documentação interativa — permite testar as rotas e ver request/response no navegador |
+| **Redoc** | `/api/redoc/` | Documentação em formato de leitura |
+| **Schema OpenAPI** | `/api/schema/` | Arquivo OpenAPI 3 (YAML) bruto |
+
+Para autenticar no Swagger UI: faça login em `POST /accounts/login/`, copie o
+`access` token retornado, clique em **Authorize** e informe `Bearer <access>`.
+
+Você também pode exportar o schema como arquivo:
+
+```bash
+python manage.py spectacular --file schema.yml
+```
 
 ---
 
@@ -184,12 +413,26 @@ ambiente). As principais:
 
 ```
 .
-├── accounts/        # autenticação, usuários, organizações, convites e papéis
-├── analytics/       # gates e análises
-├── fcs_parser/      # upload (em chunks) e processamento de arquivos FCS
-├── citosharp/       # configuração do projeto Django (settings, urls, celery)
-├── utils/           # utilitários compartilhados (mixins etc.)
-├── docs/            # documentação adicional (ver server_config.md)
+├── accounts/            # autenticação, usuários, organizações, convites e papéis
+├── analytics/           # gates, análises estatísticas e density/heatmaps
+│   ├── models.py        #   GateModel, DashboardModel, AnalysisResult
+│   ├── views.py         #   CRUD de gates, density por gate, dados filtrados
+│   └── tasks.py         #   recalculate_gate_analysis_task
+├── fcs_parser/          # upload (em chunks) e processamento de arquivos FCS
+│   ├── models.py        #   ExperimentModel, FileModel, FileDataModel
+│   ├── views.py         #   init/chunk/complete upload, density, stats
+│   ├── tasks.py         #   process, recompute, cleanup tasks
+│   └── services/        #   lógica de negócio (pipeline unificado)
+│       ├── process_fcs.py              # parse .fcs → FCSResult
+│       ├── process_experiment_file.py  # ZIP → extract → parse → FileData
+│       ├── decompressor.py             # extração de arquivos comprimidos
+│       └── header_parser.py            # serialização de headers FCS
+├── utils/               # utilitários compartilhados
+│   ├── density.py       #   density engine (heatmap, scatter, histograma)
+│   ├── mixins.py        #   SerializerByMethodMixin
+│   └── validators.py    #   validação de ZIP
+├── citosharp/           # configuração do projeto Django (settings, urls, celery)
+├── docs/                # documentação adicional (ver server_config.md)
 ├── docker-compose.yml / docker-compose.prod.yml
 └── requirements.txt
 ```

--- a/analytics/models.py
+++ b/analytics/models.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from fcs_parser.models import ExperimentModel, FileDataModel
 
+
 # Create your models here.
 class GateModel(models.Model):
 
@@ -9,13 +10,13 @@ class GateModel(models.Model):
         db_table = "gate"
         constraints = [
             models.UniqueConstraint(
-                fields=['name', 'parent'],
-                name='unique_gate_name_per_parent',
+                fields=["name", "parent"],
+                name="unique_gate_name_per_parent",
             ),
             models.UniqueConstraint(
-                fields=['name', 'file_data'],
+                fields=["name", "file_data"],
                 condition=models.Q(parent__isnull=True),
-                name='unique_gate_name_root_level',
+                name="unique_gate_name_root_level",
             ),
         ]
 
@@ -32,11 +33,16 @@ class GateModel(models.Model):
         "self", related_name="children", on_delete=models.CASCADE, null=True, blank=True
     )
     copied_from = models.ForeignKey(
-        "self", null=True, blank=True,
+        "self",
+        null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="copies",
     )
     color = models.CharField(max_length=7, null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"Gate {self.id} – {self.name}"
 
     @classmethod
     def build_tree(cls, file_data_id):
@@ -45,14 +51,18 @@ class GateModel(models.Model):
         """
         from analytics.models import AnalysisResult
 
-        gates = list(cls.objects.filter(file_data_id=file_data_id).values(
-            "id", "name", "parent_id", "gate_coordinates", "copied_from_id", "color"
-        ))
+        gates = list(
+            cls.objects.filter(file_data_id=file_data_id).values(
+                "id", "name", "parent_id", "gate_coordinates", "copied_from_id", "color"
+            )
+        )
 
         # Busca analysis_result para todos os gates deste arquivo
         gate_ids = [g["id"] for g in gates]
         analysis_map = {}
-        for ar in AnalysisResult.objects.filter(gate_id__in=gate_ids).values("gate_id", "analysis_result"):
+        for ar in AnalysisResult.objects.filter(gate_id__in=gate_ids).values(
+            "gate_id", "analysis_result"
+        ):
             analysis_map[ar["gate_id"]] = ar["analysis_result"]
 
         # Cria um mapa de gates, preparando cada um para receber filhos
@@ -79,23 +89,35 @@ class GateModel(models.Model):
         return roots
 
 
-
 class DashboardModel(models.Model):
 
     class Meta:
         db_table = "dashboard"
-        unique_together = ('name', 'file_data')
+        unique_together = ("name", "file_data")
 
     name = models.CharField(max_length=50)
     dashboard_config = models.JSONField(default=dict)
     created_at = models.DateTimeField(auto_now_add=True)
     file_data = models.ForeignKey(
-        FileDataModel, related_name="dashboards", on_delete=models.CASCADE, null=True, blank=True
+        FileDataModel,
+        related_name="dashboards",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
     )
+
+    def __str__(self) -> str:
+        return f"Dashboard {self.id} – {self.name}"
+
 
 class AnalysisResult(models.Model):
     class Meta:
-        db_table = 'analysis_result'
-        
-    gate = models.OneToOneField(GateModel, on_delete=models.CASCADE, primary_key=True, related_name='analysis_result')
+        db_table = "analysis_result"
+
+    gate = models.OneToOneField(
+        GateModel,
+        on_delete=models.CASCADE,
+        primary_key=True,
+        related_name="analysis_result",
+    )
     analysis_result = models.JSONField(default=dict)

--- a/analytics/tasks.py
+++ b/analytics/tasks.py
@@ -1,94 +1,107 @@
-# seu_projeto_django/analytics/tasks.py
+from __future__ import annotations
+
+import logging
 
 from celery import shared_task
 import pandas as pd
-import numpy as np # Ainda útil para cálculos estatísticos
-# import io # Não mais necessário se não for ler o arquivo binário direto
+import numpy as np
 
-# Importe os modelos necessários para as tasks
 from .models import GateModel, AnalysisResult
-# Importe o FileDataModel do seu app fcs_parser
-# Garanta que o caminho de importação esteja correto para o seu projeto
-from fcs_parser.models import FileDataModel 
+from fcs_parser.models import FileDataModel
 
-# --- Funções de Lógica de Negócio (Revisadas) ---
+logger = logging.getLogger(__name__)
 
-def load_fcs_data_from_file_data_model(file_data_id):
-    """
-    Carrega os dados FCS do campo `data_set` de um FileDataModel
-    e retorna como um DataFrame Pandas.
-    """
+
+def load_fcs_data_from_file_data_model(file_data_id: int) -> pd.DataFrame:
+    """Load FCS data from a FileDataModel and return as a DataFrame."""
     try:
         file_data_instance = FileDataModel.objects.get(id=file_data_id)
-        
-        
-        fcs_df = file_data_instance.get_dataframe()
-       
-        return fcs_df
+        return file_data_instance.get_dataframe()
     except FileDataModel.DoesNotExist:
-        print(f"FileDataModel com ID {file_data_id} não encontrado na task.")
+        logger.error("FileDataModel com ID %s não encontrado.", file_data_id)
         return pd.DataFrame()
     except Exception as e:
-        print(f"Erro na task ao carregar dados FCS do FileDataModel para ID {file_data_id}: {e}")
+        logger.error(
+            "Erro ao carregar dados FCS para FileDataModel %s: %s",
+            file_data_id,
+            e,
+        )
         return pd.DataFrame()
-
-
 
 
 def apply_gate_to_data(fcs_data_df, gate_coordinates, x_param, y_param):
-   
+
     if fcs_data_df.empty:
         return pd.DataFrame()
 
     filtered_data = fcs_data_df.copy()
 
     if x_param not in filtered_data.columns or y_param not in filtered_data.columns:
-        print(f"Aviso na task: Parâmetros de eixo '{x_param}' ou '{y_param}' não encontrados nos dados.")
+        logger.warning(
+            "Parâmetros '%s' ou '%s' não encontrados nos dados.", x_param, y_param
+        )
         return pd.DataFrame()
 
-    if gate_coordinates.get('type') == 'polygon':
+    if gate_coordinates.get("type") == "polygon":
         from utils.density import _points_in_polygon
 
-        vertices = gate_coordinates.get('vertices') or []
+        vertices = gate_coordinates.get("vertices") or []
         if len(vertices) < 3:
-            print("Aviso na task: poligono com menos de 3 vertices. Ignorando.")
+            logger.warning("Polígono com menos de 3 vértices. Ignorando.")
             return pd.DataFrame()
         mask = _points_in_polygon(
             filtered_data[x_param].values, filtered_data[y_param].values, vertices
         )
         return filtered_data[mask]
 
-    if 'startX' in gate_coordinates and 'endX' in gate_coordinates and \
-       'startY' in gate_coordinates and 'endY' in gate_coordinates:
-        min_x = gate_coordinates.get('startX')
-        max_x = gate_coordinates.get('endX')
-        min_y = gate_coordinates.get('startY')
-        max_y = gate_coordinates.get('endY')
+    if (
+        "startX" in gate_coordinates
+        and "endX" in gate_coordinates
+        and "startY" in gate_coordinates
+        and "endY" in gate_coordinates
+    ):
+        min_x = gate_coordinates.get("startX")
+        max_x = gate_coordinates.get("endX")
+        min_y = gate_coordinates.get("startY")
+        max_y = gate_coordinates.get("endY")
 
         filtered_data = filtered_data[
-            (filtered_data[x_param] >= min_x) & (filtered_data[x_param] <= max_x) &
-            (filtered_data[y_param] >= min_y) & (filtered_data[y_param] <= max_y)
+            (filtered_data[x_param] >= min_x)
+            & (filtered_data[x_param] <= max_x)
+            & (filtered_data[y_param] >= min_y)
+            & (filtered_data[y_param] <= max_y)
         ]
     else:
-        print(f"Aviso na task: Formato de gate_coordinates desconhecido para o gate. Assumindo que não é retangular ou falta dados.")
-        return pd.DataFrame() # Retorna vazio se não puder aplicar o gate
-    
+        logger.warning("Formato de gate_coordinates desconhecido.")
+        return pd.DataFrame()
+
     return filtered_data
 
 
-def calculate_cytometry_metrics(gated_data_df, total_events_in_file, parent_gated_data_df=None, all_channel_names=None):
-  
+def calculate_cytometry_metrics(
+    gated_data_df,
+    total_events_in_file,
+    parent_gated_data_df=None,
+    all_channel_names=None,
+):
+
     metrics = {
         "summary_metrics": {
             "count": len(gated_data_df),
-            "percent_of_total_population": len(gated_data_df) / total_events_in_file if total_events_in_file > 0 else 0,
-            "percent_of_parent_population": 0
+            "percent_of_total_population": (
+                len(gated_data_df) / total_events_in_file
+                if total_events_in_file > 0
+                else 0
+            ),
+            "percent_of_parent_population": 0,
         },
-        "channel_statistics": {}
+        "channel_statistics": {},
     }
 
     if parent_gated_data_df is not None and len(parent_gated_data_df) > 0:
-        metrics["summary_metrics"]["percent_of_parent_population"] = len(gated_data_df) / len(parent_gated_data_df)
+        metrics["summary_metrics"]["percent_of_parent_population"] = len(
+            gated_data_df
+        ) / len(parent_gated_data_df)
 
     if all_channel_names:
         for channel in all_channel_names:
@@ -97,12 +110,12 @@ def calculate_cytometry_metrics(gated_data_df, total_events_in_file, parent_gate
                 mean_val = channel_data.mean()
                 median_val = channel_data.median()
                 std_dev_val = channel_data.std()
-                
+
                 metrics["channel_statistics"][channel] = {
                     "mean_mfi": mean_val,
                     "median_mfi": median_val,
                     "std_dev": std_dev_val,
-                    "cv": (std_dev_val / mean_val * 100) if mean_val != 0 else 0
+                    "cv": (std_dev_val / mean_val * 100) if mean_val != 0 else 0,
                 }
 
     return metrics
@@ -124,16 +137,18 @@ def recalculate_gate_analysis_task(self, gate_id):
     """
     from utils.density import apply_gate_filter, normalize_columns
 
-    print(f"Tarefa {self.request.id}: Iniciando recálculo para gate ID {gate_id}...")
+    logger.info("Iniciando recálculo para gate ID %s...", gate_id)
     try:
         gate = GateModel.objects.select_related(
-            'dashboard', 'file_data', 'parent',
+            "dashboard",
+            "file_data",
+            "parent",
         ).get(id=gate_id)
 
         # --- 1. Dados brutos do arquivo ----------------------------------
         fcs_data_df = load_fcs_data_from_file_data_model(gate.file_data.id)
         if fcs_data_df.empty:
-            print(f"Tarefa {self.request.id}: Dados FCS vazios para gate {gate_id}. Abortando.")
+            logger.warning("Dados FCS vazios para gate %s. Abortando.", gate_id)
             return
 
         dataset = normalize_columns(fcs_data_df)
@@ -173,14 +188,19 @@ def recalculate_gate_analysis_task(self, gate_id):
 
         AnalysisResult.objects.update_or_create(
             gate=gate,
-            defaults={'analysis_result': new_analysis_results},
+            defaults={"analysis_result": new_analysis_results},
         )
-        print(f"Tarefa {self.request.id}: Recálculo concluído para gate '{gate.name}' (ID: {gate_id}).")
+        logger.info("Recálculo concluído para gate '%s' (ID: %s).", gate.name, gate_id)
 
         for child_gate in gate.children.all():
             recalculate_gate_analysis_task.delay(child_gate.id)
 
     except GateModel.DoesNotExist:
-        print(f"Tarefa {self.request.id}: GateModel com ID {gate_id} não encontrado.")
+        logger.error("GateModel com ID %s não encontrado.", gate_id)
     except Exception as e:
-        print(f"Tarefa {self.request.id}: Erro inesperado ao recalcular gate {gate_id}: {e}", exc_info=True)
+        logger.error(
+            "Erro inesperado ao recalcular gate %s: %s",
+            gate_id,
+            e,
+            exc_info=True,
+        )

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -341,6 +341,47 @@ class GateDensityView(APIView):
         return Response(payload, status=status.HTTP_200_OK)
 
 
+def _resolve_target_parent(source_gate, target_fd_id, id_map):
+    """Resolve the parent for *source_gate* inside the target file.
+
+    If the source gate's parent was already created in the target (present in
+    *id_map*), return that id.  Otherwise walk up the source ancestry and try
+    to match the same name hierarchy in the target — this ensures that when a
+    user applies a sub-tree (e.g. CD3+ under Lymphocytes), the code finds the
+    existing 'Lymphocytes' in the target and places the gate underneath it
+    instead of creating a duplicate at root level.
+
+    Returns ``None`` when no matching hierarchy exists (gate becomes root).
+    """
+    if source_gate.parent_id is None:
+        return None
+
+    if source_gate.parent_id in id_map:
+        return id_map[source_gate.parent_id]
+
+    # Build the ancestry path (root-first) for the unmapped parent chain.
+    ancestry = []
+    current = source_gate.parent
+    while current and current.id not in id_map:
+        ancestry.insert(0, current)
+        current = current.parent
+
+    # If we reached a gate already in id_map, start from there.
+    target_parent_id = id_map.get(current.id) if current else None
+
+    for ancestor in ancestry:
+        match = GateModel.objects.filter(
+            file_data_id=target_fd_id,
+            name=ancestor.name,
+            parent_id=target_parent_id,
+        ).first()
+        if match is None:
+            return target_parent_id  # partial match; attach here
+        target_parent_id = match.id
+
+    return target_parent_id
+
+
 class ApplyGateView(APIView):
     """POST /analytics/gate/apply — copy gates to other files (FlowJo semantics).
 
@@ -391,7 +432,12 @@ class ApplyGateView(APIView):
             )
 
         source_gates = list(
-            GateModel.objects.filter(id__in=source_ids).select_related("dashboard")
+            GateModel.objects.filter(id__in=source_ids).select_related(
+                "dashboard",
+                "parent",
+                "parent__parent",
+                "parent__parent__parent",
+            )
         )
         if len(source_gates) != len(source_ids):
             return Response(
@@ -450,7 +496,7 @@ class ApplyGateView(APIView):
 
                 for gate in ordered_gates:
                     # Determine new parent in target file.
-                    new_parent_id = id_map.get(gate.parent_id)
+                    new_parent_id = _resolve_target_parent(gate, target_fd_id, id_map)
 
                     # Conflict check.
                     existing = GateModel.objects.filter(

--- a/analytics/views.py
+++ b/analytics/views.py
@@ -1,6 +1,8 @@
-
+import json
+import logging
 from collections import deque
 
+import pandas as pd
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema, OpenApiParameter, inline_serializer
@@ -22,36 +24,37 @@ from utils.density import (
     set_cached_density,
     subsample_scatter,
 )
-import pandas as pd
-import json
 
-# Create your views here.
+logger = logging.getLogger(__name__)
+
 
 class CreateGateView(generics.CreateAPIView):
     serializer_class = GateSerializer
 
     def post(self, request, *args, **kwargs):
         data = request.data.copy()
-        dashboard_data = data.pop('dashboard', None)
+        dashboard_data = data.pop("dashboard", None)
 
         dashboard_serializer = DashboardSerializer(data=dashboard_data)
         dashboard_serializer.is_valid(raise_exception=True)
 
         dash_instance = dashboard_serializer.save()
-        data['dashboard'] = dash_instance.id
+        data["dashboard"] = dash_instance.id
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         gate_instance = serializer.save()
-        
+
         # Dispara recálculo de métricas (% parent, % total) para o gate criado
         from analytics.tasks import recalculate_gate_analysis_task
+
         recalculate_gate_analysis_task.delay(gate_instance.id)
-        
+
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class UpdateGateView(generics.RetrieveUpdateDestroyAPIView):
     """PATCH/DELETE /analytics/gate/<gate_id> — rename or delete a gate."""
+
     serializer_class = GateSerializer
     lookup_url_kwarg = "gate_id"
     queryset = GateModel.objects.all()
@@ -79,10 +82,12 @@ class UpdateGateView(generics.RetrieveUpdateDestroyAPIView):
             gate.save(update_fields=update_fields)
 
         from analytics.tasks import recalculate_gate_analysis_task
+
         recalculate_gate_analysis_task.delay(gate.id)
 
         if new_coords is not None:
             from utils.density import invalidate_density
+
             invalidate_density(gate.file_data_id)
 
         serializer = self.get_serializer(gate)
@@ -96,8 +101,10 @@ class GetGateDataView(generics.ListAPIView):
     def get_object(self):
         gate_id = self.kwargs.get(self.lookup_url_kwarg)
         return get_object_or_404(GateModel, pk=gate_id)
-    
-    def _apply_gate_filter(self, dataset: pd.DataFrame, gate: GateModel) -> pd.DataFrame:
+
+    def _apply_gate_filter(
+        self, dataset: pd.DataFrame, gate: GateModel
+    ) -> pd.DataFrame:
         """Aplica o filtro de um gate (retangulo ou poligono) ao dataset.
 
         Delega ao helper compartilhado (utils.density.apply_gate_filter), que
@@ -105,59 +112,122 @@ class GetGateDataView(generics.ListAPIView):
         """
         return apply_gate_filter(dataset, gate)
 
-
     def get(self, request, *args, **kwargs):
-              
+
         target_gate = self.get_object()
-        
+
         current_gate = target_gate
-        gate_path = [current_gate] 
+        gate_path = [current_gate]
 
         while current_gate.parent:
             current_gate = current_gate.parent
-            gate_path.insert(0, current_gate) 
+            gate_path.insert(0, current_gate)
 
         root_gate = gate_path[0]
         file_data_instance = root_gate.file_data
 
         dataset = file_data_instance.get_dataframe()
 
-        dataset.columns = dataset.columns.str.replace(" ", "")
-        dataset.columns = dataset.columns.str.replace("-", "_")
-        dataset.columns = dataset.columns.str.lower()
+        dataset = normalize_columns(dataset)
 
         for gate_in_path in gate_path:
             dataset = self._apply_gate_filter(dataset, gate_in_path)
             if dataset.empty:
-                print(f"Dataset vazio após filtrar pelo gate '{gate_in_path.name}'. Parando processamento.")
                 break
         limit = request.query_params.get("limit", 10000)
         try:
             limit = int(limit)
         except ValueError:
-            limit = 10000 
+            limit = 10000
         dataset = dataset.head(limit)
         file_data_instance.data_set = json.loads(dataset.to_json(orient="records"))
         serializer = ParamListDataSerializer(file_data_instance)
-        return Response(serializer.data, status=status.HTTP_200_OK) 
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
 class GateDensityView(APIView):
     """Return density (heatmap) or subsampled scatter for a gate's filtered data."""
 
     @extend_schema(
         parameters=[
-            OpenApiParameter(name="x", type=str, required=True, description="X-axis parameter (e.g. FSC-A)"),
-            OpenApiParameter(name="y", type=str, required=True, description="Y-axis parameter (e.g. SSC-A)"),
-            OpenApiParameter(name="mode", type=str, required=False, description="'heatmap' (default) or 'scatter'"),
-            OpenApiParameter(name="bins", type=int, required=False, description="Bins for heatmap (default 200)"),
-            OpenApiParameter(name="sample", type=int, required=False, description="Max points for scatter (default 5000)"),
-            OpenApiParameter(name="xscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
-            OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
-            OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
-            OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
-            OpenApiParameter(name="xmin", type=float, required=False, description="Lower bound for X axis (raw value)"),
-            OpenApiParameter(name="xmax", type=float, required=False, description="Upper bound for X axis (raw value)"),
-            OpenApiParameter(name="ymin", type=float, required=False, description="Lower bound for Y axis (raw value)"),
-            OpenApiParameter(name="ymax", type=float, required=False, description="Upper bound for Y axis (raw value)"),
+            OpenApiParameter(
+                name="x",
+                type=str,
+                required=True,
+                description="X-axis parameter (e.g. FSC-A)",
+            ),
+            OpenApiParameter(
+                name="y",
+                type=str,
+                required=True,
+                description="Y-axis parameter (e.g. SSC-A)",
+            ),
+            OpenApiParameter(
+                name="mode",
+                type=str,
+                required=False,
+                description="'heatmap' (default) or 'scatter'",
+            ),
+            OpenApiParameter(
+                name="bins",
+                type=int,
+                required=False,
+                description="Bins for heatmap (default 200)",
+            ),
+            OpenApiParameter(
+                name="sample",
+                type=int,
+                required=False,
+                description="Max points for scatter (default 5000)",
+            ),
+            OpenApiParameter(
+                name="xscale",
+                type=str,
+                required=False,
+                description="'linear' or 'biex' (default: heuristic by channel)",
+            ),
+            OpenApiParameter(
+                name="yscale",
+                type=str,
+                required=False,
+                description="'linear' or 'biex' (default: heuristic by channel)",
+            ),
+            OpenApiParameter(
+                name="cofactor",
+                type=float,
+                required=False,
+                description="arcsinh cofactor for biex (default 150)",
+            ),
+            OpenApiParameter(
+                name="cutoff",
+                type=int,
+                required=False,
+                description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)",
+            ),
+            OpenApiParameter(
+                name="xmin",
+                type=float,
+                required=False,
+                description="Lower bound for X axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="xmax",
+                type=float,
+                required=False,
+                description="Upper bound for X axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="ymin",
+                type=float,
+                required=False,
+                description="Lower bound for Y axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="ymax",
+                type=float,
+                required=False,
+                description="Upper bound for Y axis (raw value)",
+            ),
         ],
         responses=inline_serializer(
             name="GateDensityResponse",
@@ -188,8 +258,18 @@ class GateDensityView(APIView):
         gate = get_object_or_404(GateModel, pk=gate_id)
 
         cache_key = density_cache_key(
-            "gate", gate.file_data_id, gate_id, x_param, y_param, mode, bins, sample,
-            x_scale, y_scale, cofactor, cutoff,
+            "gate",
+            gate.file_data_id,
+            gate_id,
+            x_param,
+            y_param,
+            mode,
+            bins,
+            sample,
+            x_scale,
+            y_scale,
+            cofactor,
+            cutoff,
         )
         if x_range:
             cache_key += f":xr{x_range[0]}:{x_range[1]}"
@@ -213,14 +293,42 @@ class GateDensityView(APIView):
             if dataset.empty:
                 break
 
-        base = {"mode": mode, "total_events": len(dataset), "x_label": x_param, "y_label": y_param}
+        base = {
+            "mode": mode,
+            "total_events": len(dataset),
+            "x_label": x_param,
+            "y_label": y_param,
+        }
 
         if mode == "scatter":
-            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
+            result = subsample_scatter(
+                dataset,
+                x_param,
+                y_param,
+                sample,
+                x_scale,
+                y_scale,
+                cofactor,
+                x_range,
+                y_range,
+            )
         elif mode == "histogram":
-            result = compute_histogram(dataset, x_param, bins, x_scale, cofactor, x_range)
+            result = compute_histogram(
+                dataset, x_param, bins, x_scale, cofactor, x_range
+            )
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
+            result = compute_density(
+                dataset,
+                x_param,
+                y_param,
+                bins,
+                x_scale,
+                y_scale,
+                cofactor,
+                cutoff,
+                x_range,
+                y_range,
+            )
 
         if result is None:
             return Response(
@@ -249,10 +357,16 @@ class ApplyGateView(APIView):
         request=inline_serializer(
             name="ApplyGateRequest",
             fields={
-                "source_gate_ids": serializers.ListField(child=serializers.IntegerField()),
-                "target_file_data_ids": serializers.ListField(child=serializers.IntegerField()),
+                "source_gate_ids": serializers.ListField(
+                    child=serializers.IntegerField()
+                ),
+                "target_file_data_ids": serializers.ListField(
+                    child=serializers.IntegerField()
+                ),
                 "recursive": serializers.BooleanField(default=True),
-                "on_conflict": serializers.ChoiceField(choices=["rename", "replace", "skip"], default="rename"),
+                "on_conflict": serializers.ChoiceField(
+                    choices=["rename", "replace", "skip"], default="rename"
+                ),
             },
         ),
         responses=inline_serializer(
@@ -276,9 +390,14 @@ class ApplyGateView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        source_gates = list(GateModel.objects.filter(id__in=source_ids).select_related("dashboard"))
+        source_gates = list(
+            GateModel.objects.filter(id__in=source_ids).select_related("dashboard")
+        )
         if len(source_gates) != len(source_ids):
-            return Response({"detail": "One or more source gates not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "One or more source gates not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         # Exclude source file(s) from target list to prevent self-copy.
         source_file_ids = {g.file_data_id for g in source_gates}
@@ -383,11 +502,13 @@ class ApplyGateView(APIView):
                     id_map[gate.id] = new_gate.id
                     file_created += 1
 
-                details.append({
-                    "file_data_id": target_fd_id,
-                    "gates_created": file_created,
-                    "gates_skipped": file_skipped,
-                })
+                details.append(
+                    {
+                        "file_data_id": target_fd_id,
+                        "gates_created": file_created,
+                        "gates_skipped": file_skipped,
+                    }
+                )
                 total_created += file_created
                 total_skipped += file_skipped
 
@@ -397,7 +518,9 @@ class ApplyGateView(APIView):
         for detail in details:
             fd_id = detail["file_data_id"]
             root_gates = GateModel.objects.filter(
-                file_data_id=fd_id, parent__isnull=True, copied_from__isnull=False,
+                file_data_id=fd_id,
+                parent__isnull=True,
+                copied_from__isnull=False,
             )
             for rg in root_gates:
                 recalculate_gate_analysis_task.delay(rg.id)

--- a/citosharp/settings.py
+++ b/citosharp/settings.py
@@ -14,34 +14,35 @@ from pathlib import Path
 import os
 from celery.schedules import crontab
 from dotenv import load_dotenv
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-env_path = BASE_DIR / '.env'
+env_path = BASE_DIR / ".env"
 if env_path.exists():
     load_dotenv(env_path)
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY')
+SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', 'True').lower() in ('true', '1', 't', 'yes')
-REDIS_HOST = os.getenv('REDIS_HOST', 'redis')
-REDIS_PORT = os.getenv('REDIS_PORT', '6379')
+DEBUG = os.environ.get("DEBUG", "True").lower() in ("true", "1", "t", "yes")
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = os.getenv("REDIS_PORT", "6379")
 # APPEND_SLASH = True
-DATA_UPLOAD_MAX_MEMORY_SIZE = 150 * 1024 * 1024  
+DATA_UPLOAD_MAX_MEMORY_SIZE = 150 * 1024 * 1024
 FILE_UPLOAD_MAX_MEMORY_SIZE = 150 * 1024 * 1024
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "*").split(",")
 MEDIA_ROOT = os.environ.get("MEDIA_ROOT", BASE_DIR / "uploads")
 MEDIA_URL = "/media/"
-CELERY_BROKER_URL = f'redis://{REDIS_HOST}:{REDIS_PORT}/0'
-CELERY_RESULT_BACKEND = f'redis://{REDIS_HOST}:{REDIS_PORT}/0'
-CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TIMEZONE = 'America/Sao_Paulo'
+CELERY_BROKER_URL = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"
+CELERY_RESULT_BACKEND = f"redis://{REDIS_HOST}:{REDIS_PORT}/0"
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = "America/Sao_Paulo"
 CELERY_TASK_TRACK_STARTED = True
 
 # Celery Beat: limpeza semanal de Parquet orfao/frio (recriavel do .fcs).
@@ -51,6 +52,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "fcs_parser.tasks.cleanup_cold_parquet_task",
         "schedule": crontab(hour=3, minute=0, day_of_week="sunday"),
         "kwargs": {"max_idle_days": PARQUET_MAX_IDLE_DAYS},
+    },
+    "cleanup-ephemeral-fcs": {
+        "task": "fcs_parser.tasks.cleanup_ephemeral_fcs_task",
+        "schedule": crontab(hour=4, minute=0, day_of_week="sunday"),
     },
 }
 
@@ -67,27 +72,26 @@ DENSITY_CACHE_TTL = int(os.getenv("DENSITY_CACHE_TTL", 3600))
 # Application definition
 
 INSTALLED_APPS = [
-    'corsheaders',
+    "corsheaders",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    'fcs_parser',
-    'analytics',
+    "fcs_parser",
+    "analytics",
     "rest_framework",
     "rest_framework_simplejwt",
-    'drf_spectacular',
-    'accounts',
-    
+    "drf_spectacular",
+    "accounts",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    'corsheaders.middleware.CorsMiddleware',
-    'django.middleware.common.CommonMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -115,15 +119,15 @@ SPECTACULAR_SETTINGS = {
     },
 }
 
-CORS_ALLOW_ALL_ORIGINS=True
+CORS_ALLOW_ALL_ORIGINS = True
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 ROOT_URLCONF = "citosharp.urls"
-DEFAULT_FROM_EMAIL = os.getenv('EMAIL_HOST_USER')
+DEFAULT_FROM_EMAIL = os.getenv("EMAIL_HOST_USER")
 FRONTEND_URL = "https://app.project-pandora.com.br"
 
 TEMPLATES = [
@@ -147,7 +151,7 @@ WSGI_APPLICATION = "citosharp.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
-if os.environ.get('TEST'):
+if os.environ.get("TEST"):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
@@ -157,12 +161,12 @@ if os.environ.get('TEST'):
 else:
     DATABASES = {
         "default": {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': os.getenv('DATABASE_NAME'),
-            'USER': os.getenv('DATABASE_USER'),
-            'PASSWORD': os.getenv('DATABASE_PASSWORD'),
-            'HOST': os.getenv('DATABASE_HOST'),
-            'PORT': os.getenv('DATABASE_PORT'),
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.getenv("DATABASE_NAME"),
+            "USER": os.getenv("DATABASE_USER"),
+            "PASSWORD": os.getenv("DATABASE_PASSWORD"),
+            "HOST": os.getenv("DATABASE_HOST"),
+            "PORT": os.getenv("DATABASE_PORT"),
         }
     }
 
@@ -202,7 +206,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
 STATIC_URL = "static/"
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')  
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 

--- a/fcs_parser/migrations/0006_experimentmodel_zip_path.py
+++ b/fcs_parser/migrations/0006_experimentmodel_zip_path.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "fcs_parser",
+            "0005_filedatamodel_fcs_path_filedatamodel_last_accessed_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="experimentmodel",
+            name="zip_path",
+            field=models.CharField(blank=True, max_length=512, null=True),
+        ),
+    ]

--- a/fcs_parser/models.py
+++ b/fcs_parser/models.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import logging
 import os
 
 import pandas as pd
@@ -6,6 +9,8 @@ from django.db import models
 from django.contrib.postgres.fields import ArrayField
 from django.utils import timezone
 from accounts.models import Organization, User
+
+logger = logging.getLogger(__name__)
 
 
 def parquet_storage_dir() -> str:
@@ -34,14 +39,14 @@ class ExperimentModel(models.Model):
     values = ArrayField(models.TextField(), blank=True, default=list)
     active = models.BooleanField(default=True)
     status = models.CharField(max_length=50, choices=STATUS_CHOICES, default="new")
-    file_status = models.CharField(max_length=50, choices=FILE_STATUS_CHOICES, default="pending")
+    file_status = models.CharField(
+        max_length=50, choices=FILE_STATUS_CHOICES, default="pending"
+    )
     total_chunks = models.IntegerField(null=True, blank=True)
     received_chunks = ArrayField(models.IntegerField(), default=list, blank=True)
     error_info = models.JSONField(blank=True, default=dict)
     organization = models.ForeignKey(
-        Organization,
-        on_delete=models.CASCADE,
-        related_name="experiments", null=True
+        Organization, on_delete=models.CASCADE, related_name="experiments", null=True
     )
 
     created_by = models.ForeignKey(
@@ -49,8 +54,12 @@ class ExperimentModel(models.Model):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name="created_experiments"
+        related_name="created_experiments",
     )
+    zip_path = models.CharField(max_length=512, null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"Experiment {self.id} – {self.title} ({self.status})"
 
 
 class FileModel(models.Model):
@@ -67,6 +76,9 @@ class FileModel(models.Model):
     def get_file_url(self):
         return settings.MEDIA_URL + str(self.file)
 
+    def __str__(self) -> str:
+        return f"File {self.id} – {self.file_name}"
+
 
 class FileDataModel(models.Model):
     """Model for Data on each file"""
@@ -75,14 +87,13 @@ class FileDataModel(models.Model):
     file_name = models.CharField(max_length=256, null=True)
     experiment = models.ForeignKey(ExperimentModel, on_delete=models.CASCADE)
     headers = models.JSONField()
-    # data_set (JSON no banco) vira legado: novas linhas guardam o parseado em
-    # Parquet (parquet_path) e regeneram a partir do .fcs original (fcs_path).
+    # Legacy: data_set JSON in the DB. New rows use Parquet on disk.
     data_set = models.JSONField(null=True, blank=True)
-    # Caminho do Parquet com o dataset parseado (cache morno, recriavel).
+    # Parquet cache path (warm cache, regenerable from the ZIP).
     parquet_path = models.CharField(max_length=512, null=True, blank=True)
-    # Caminho do .fcs original (fonte da verdade, usado para reprocessar).
+    # Legacy: direct .fcs path (kept for backward compatibility with old data).
     fcs_path = models.CharField(max_length=512, null=True, blank=True)
-    # Ultimo acesso ao dataset; usado pela limpeza de Parquet frio.
+    # Last access timestamp; used by cold-Parquet cleanup.
     last_accessed = models.DateTimeField(null=True, blank=True)
     file = models.ForeignKey(
         FileModel, on_delete=models.CASCADE, related_name="extracted_data"
@@ -90,6 +101,9 @@ class FileDataModel(models.Model):
 
     class Meta:
         db_table = "file_data"
+
+    def __str__(self) -> str:
+        return f"FileData {self.id} – {self.file_name}"
 
     def _touch(self):
         """Marca o ultimo acesso sem disparar um save completo."""
@@ -108,11 +122,11 @@ class FileDataModel(models.Model):
         self.save(update_fields=["parquet_path", "data_set"])
 
     def get_dataframe(self) -> pd.DataFrame:
-        """Retorna os eventos como DataFrame, reconstruindo o cache se preciso.
+        """Return events as a DataFrame, rebuilding the cache when needed.
 
-        Cascata: Parquet (cache) -> reparse do .fcs (fonte) -> data_set (legado).
+        Cascade: Parquet (L2 cache) -> re-extract from ZIP (L0 source) -> data_set (legacy).
         """
-        # 1) Cache morno: Parquet em disco.
+        # 1) Warm cache: Parquet on disk.
         if self.parquet_path and os.path.exists(self.parquet_path):
             try:
                 df = pd.read_parquet(self.parquet_path)
@@ -121,35 +135,72 @@ class FileDataModel(models.Model):
             except Exception:
                 pass
 
-        # 2) Fonte da verdade: reparseia o .fcs original e regenera o Parquet.
-        if self.fcs_path and os.path.exists(self.fcs_path):
-            from fcs_parser.services import process_fcs_file
+        # 2) Source of truth: extract .fcs from ZIP, reparse, rebuild Parquet.
+        df = self._rebuild_from_zip()
+        if df is not None:
+            return df
 
-            processed = process_fcs_file(self.fcs_path)
-            if isinstance(processed, list):
-                df = pd.DataFrame(processed[1])
-                try:
-                    self.save_dataframe(df)
-                    self._touch()
-                except Exception:
-                    pass
+        # 3) Legacy: old fcs_path on disk (pre-ZIP migration data).
+        if self.fcs_path and os.path.exists(self.fcs_path):
+            df = self._rebuild_from_fcs_path()
+            if df is not None:
                 return df
 
-        # 3) Legado: data_set JSON ainda no banco.
+        # 4) Legacy fallback: data_set JSON still in the DB.
         if self.data_set:
             return pd.DataFrame(self.data_set)
 
         return pd.DataFrame()
 
-    def is_valid(self, raise_exception=False):
-        headers = self.initial_data.get("headers")
-        data_set = self.initial_data.get("data_set")
+    def _rebuild_from_zip(self) -> pd.DataFrame | None:
+        """Extract .fcs from the experiment's ZIP and rebuild the Parquet cache."""
+        from fcs_parser.services.process_experiment_file import extract_fcs_from_zip
+        from fcs_parser.services.process_fcs import process_fcs_file
 
-        if not self.validate_json_field(headers):
-            self.errors["headers"] = ["Invalid field headers."]
-        if not self.validate_json_field(data_set):
-            self.errors["data_set"] = ["Invalid field data_set."]
+        experiment = self.experiment
+        if not getattr(experiment, "zip_path", None):
+            return None
 
-        return super().is_valid(raise_exception)
+        fcs_path = extract_fcs_from_zip(experiment, self.file_name)
+        if fcs_path is None:
+            return None
 
+        try:
+            result = process_fcs_file(fcs_path)
+            df = pd.DataFrame(result.data)
+            try:
+                self.save_dataframe(df)
+                self._touch()
+            except Exception:
+                logger.warning("Failed to save Parquet cache for FileData %s.", self.pk)
+            return df
+        except ValueError:
+            logger.warning("Failed to reparse .fcs for FileData %s.", self.pk)
+            return None
+        finally:
+            if fcs_path and os.path.exists(fcs_path):
+                os.remove(fcs_path)
 
+    def _rebuild_from_fcs_path(self) -> pd.DataFrame | None:
+        """Legacy fallback: rebuild Parquet from a direct .fcs path on disk."""
+        from fcs_parser.services.process_fcs import process_fcs_file
+
+        try:
+            result = process_fcs_file(self.fcs_path)
+            df = pd.DataFrame(result.data)
+            try:
+                self.save_dataframe(df)
+                self._touch()
+            except Exception:
+                logger.warning(
+                    "Failed to save Parquet cache for FileData %s (fcs_path).",
+                    self.pk,
+                )
+            return df
+        except ValueError:
+            logger.warning(
+                "Failed to reparse .fcs at '%s' for FileData %s.",
+                self.fcs_path,
+                self.pk,
+            )
+            return None

--- a/fcs_parser/serializers.py
+++ b/fcs_parser/serializers.py
@@ -1,10 +1,7 @@
-import json
 from rest_framework import serializers
 from analytics.serializers import ListGateSerializer
 from utils.validators import validate_zip_file
 from .models import ExperimentModel, FileDataModel
-
-
 
 
 class ExperimentSerializer(serializers.ModelSerializer):
@@ -32,18 +29,6 @@ class ExperimentSerializer(serializers.ModelSerializer):
         return super().validate(data)
 
 
-# class GateSerializer(serializers.ModelSerializer):
-#     parent = serializers.PrimaryKeyRelatedField(queryset=GateModel.objects.all(), allow_null=True, required=False)
-#     class Meta:
-#         model = GateModel
-#         fields = '__all__'
-#         read_only_fields = ['id', 'created_at']
-#     def get_children(self, obj):
-#         # Serializa os filhos do gate
-#         children = obj.children.all()
-#         return GateSerializer(children, many=True).data
-
-
 class ListFileDataSerializer(serializers.ModelSerializer):
 
     gates = ListGateSerializer(many=True, read_only=True)
@@ -53,29 +38,10 @@ class ListFileDataSerializer(serializers.ModelSerializer):
         fields = ["id", "file_name", "gates"]
         read_only_fields = ["id"]
 
-    def is_valid(self, raise_exception=False):
-
-        headers = self.initial_data.get("headers")
-        data_set = self.initial_data.get("data_set")
-
-        if not self.validate_json_field(headers):
-            self.errors["headers"] = ["Formato inválido para o campo headers."]
-        if not self.validate_json_field(data_set):
-            self.errors["data_set"] = ["Formato inválido para o campo data_set."]
-
-        return super().is_valid(raise_exception)
-
-    def validate_json_field(self, field_data):
-        try:
-            json.loads(field_data)
-            return True
-        except ValueError:
-            return False
-
 
 class ParamListDataSerializer(serializers.ModelSerializer):
     gates = ListGateSerializer(many=True, read_only=True)
-    
+
     class Meta:
         model = FileDataModel
         fields = ["id", "file_name", "data_set", "gates"]

--- a/fcs_parser/services/__init__.py
+++ b/fcs_parser/services/__init__.py
@@ -1,4 +1,8 @@
 from .decompressor import *
 from .header_parser import *
-from .process_fcs import *
-from .process_experiment_file import *
+from .process_fcs import FCSResult, process_fcs_file
+from .process_experiment_file import (
+    assemble_chunks,
+    extract_fcs_from_zip,
+    process_experiment_zip,
+)

--- a/fcs_parser/services/process_experiment_file.py
+++ b/fcs_parser/services/process_experiment_file.py
@@ -1,46 +1,138 @@
+"""Unified service for processing experiment ZIP files into FileDataModels.
+
+This module is the single place where the pipeline
+ZIP → extract .fcs → parse → create FileDataModel + Parquet
+lives.  Tasks and views delegate here instead of reimplementing it.
+"""
+
+from __future__ import annotations
+
+import logging
 import os
-import traceback
+import shutil
+import zipfile
+
+import pandas as pd
 from django.conf import settings
 
 from fcs_parser.models import ExperimentModel, FileDataModel, FileModel
-from fcs_parser.services import decompres_file, process_fcs_file
+from fcs_parser.services.process_fcs import FCSResult, process_fcs_file
+
+logger = logging.getLogger(__name__)
 
 
-def process_experiment_file(file: FileModel):
+def _extract_dir(experiment_id: int) -> str:
+    """Temporary directory for extracted .fcs files (ephemeral)."""
+    return os.path.join(settings.MEDIA_ROOT, "fcs_files", str(experiment_id))
 
-    experiment_title = file.file_name
-    directory_path = os.path.join(settings.MEDIA_ROOT, "fcs_files", file.file_name)
-    file_path = os.path.join(settings.MEDIA_ROOT, file.file_name)
+
+def assemble_chunks(experiment: ExperimentModel) -> str:
+    """Concatenate uploaded chunks into the final ZIP file.
+
+    Returns the path to the assembled ZIP.
+    Raises ``ValueError`` if any chunk is missing.
+    """
+    chunk_dir = os.path.join(settings.MEDIA_ROOT, "chunks")
+    final_name = f"{experiment.id}.zip"
+    final_path = os.path.join(settings.MEDIA_ROOT, final_name)
+
+    with open(final_path, "wb") as outfile:
+        for i in range(experiment.total_chunks):
+            chunk_path = os.path.join(chunk_dir, f"{experiment.id}_{i}.part")
+            if not os.path.exists(chunk_path):
+                raise ValueError(f"Chunk {i} faltando")
+            with open(chunk_path, "rb") as f:
+                outfile.write(f.read())
+            os.remove(chunk_path)
+
+    return final_path
+
+
+def process_experiment_zip(file_model: FileModel) -> list[str]:
+    """Process the ZIP attached to *file_model*, creating FileDataModels.
+
+    This is the **single implementation** of the pipeline:
+    1. Extract ZIP → temp dir
+    2. For each .fcs inside, parse and create a ``FileDataModel``
+       with a Parquet cache.
+    3. Store the ZIP path on the ``ExperimentModel`` (source of truth).
+    4. Clean up the temp extraction directory (the .fcs files are ephemeral).
+
+    Returns the list of channel names (``values``) found in the first file.
+    """
+    experiment = file_model.experiment
+    zip_path = file_model.file.path
+    directory_path = _extract_dir(experiment.id)
+
     os.makedirs(directory_path, exist_ok=True)
-    decompres_file(file_path, directory_path)
-    experiment = file.experiment
-    values = []
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(directory_path)
+
+    values: list[str] = []
 
     try:
-        for file_name in os.listdir(directory_path):
-            if file_name.endswith(".fcs"):
-                complete_path: str = os.path.join(directory_path, file_name)
-                processed_file = process_fcs_file(complete_path)
-                experiment_id = experiment.id
-                if len(values) == 0:
-                    values = processed_file[2]
-                FileDataModel.objects.get_or_create(
-                    headers=processed_file[0],
-                    data_set=processed_file[1],
-                    experiment_id=experiment_id,
+        for root, _dirs, files in os.walk(directory_path):
+            for file_name in files:
+                if not file_name.endswith(".fcs"):
+                    continue
+
+                complete_path = os.path.join(root, file_name)
+                result: FCSResult = process_fcs_file(complete_path)
+
+                if not values:
+                    values = result.channels
+
+                file_data = FileDataModel.objects.create(
+                    headers=result.headers,
+                    data_set=None,
+                    experiment=experiment,
                     file_name=file_name,
+                    file=file_model,
                 )
-                os.remove(complete_path)
+                file_data.save_dataframe(pd.DataFrame(result.data))
+
+        # Persist the ZIP path as the experiment's source of truth.
+        experiment.zip_path = zip_path
         experiment.values = values
         experiment.status = "done"
-        experiment.save()
+        experiment.save(update_fields=["zip_path", "values", "status"])
 
-    except Exception as e:
-        error = {"error_message": str(e), "details": traceback.format_exc()}
-        error_handler(e, experiment, error)
+        logger.info(
+            "Processamento do Experimento %s ('%s') concluído.",
+            experiment.id,
+            experiment.title,
+        )
+    finally:
+        # The extracted .fcs directory is ephemeral — always clean up.
+        if os.path.isdir(directory_path):
+            shutil.rmtree(directory_path, ignore_errors=True)
+            logger.info("Diretório temporário '%s' removido.", directory_path)
+
+    return values
 
 
-def error_handler(e: Exception, experiment: ExperimentModel, error_info: dict):
-    experiment.status = "error"
-    experiment.error_info = error_info
-    experiment.save()
+def extract_fcs_from_zip(experiment: ExperimentModel, file_name: str) -> str | None:
+    """Extract a single .fcs from the experiment's ZIP (on-demand).
+
+    Returns the path to the extracted file inside a temp directory,
+    or ``None`` if the ZIP or entry is not found.
+    The caller is responsible for cleaning up the file after use.
+    """
+    zip_path = getattr(experiment, "zip_path", None)
+    if not zip_path or not os.path.exists(zip_path):
+        return None
+
+    extract_dir = _extract_dir(experiment.id)
+    os.makedirs(extract_dir, exist_ok=True)
+
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            # Find the entry matching file_name (may be nested in subdirs).
+            matching = [n for n in zf.namelist() if n.endswith(file_name)]
+            if not matching:
+                return None
+            zf.extract(matching[0], extract_dir)
+            return os.path.join(extract_dir, matching[0])
+    except (zipfile.BadZipFile, KeyError):
+        logger.warning("Falha ao extrair '%s' do ZIP '%s'.", file_name, zip_path)
+        return None

--- a/fcs_parser/services/process_fcs.py
+++ b/fcs_parser/services/process_fcs.py
@@ -1,25 +1,51 @@
+from __future__ import annotations
+
 import json
+import logging
+from dataclasses import dataclass, field
+
 import readfcs
+
 from .header_parser import serialize_value
 
+logger = logging.getLogger(__name__)
 
-def process_fcs_file(fcs_file_path: str):
+
+@dataclass
+class FCSResult:
+    """Typed container for the output of :func:`process_fcs_file`."""
+
+    headers: dict = field(default_factory=dict)
+    data: list = field(default_factory=list)
+    channels: list = field(default_factory=list)
+
+
+def process_fcs_file(fcs_file_path: str) -> FCSResult:
+    """Parse a single .fcs file and return structured data.
+
+    Raises ``ValueError`` on any processing error instead of returning
+    a bare error string.
+    """
     try:
         headers, _ = readfcs.view(fcs_file_path)
         fcsfile = readfcs.ReadFCS(fcs_file_path)
         data_set = fcsfile.data
-        channels = fcsfile.channels 
+        channels = fcsfile.channels
         data_set.columns = channels["PnN"].tolist()
-        
+
         data_set["id"] = range(1, len(data_set) + 1)
 
         json_dataset = data_set.to_json(orient="records")
 
         values = data_set.columns.tolist()
-        return [headers, json.loads(json_dataset), values]
+        return FCSResult(
+            headers=headers,
+            data=json.loads(json_dataset),
+            channels=values,
+        )
 
     except Exception as e:
-        return f"Error processing FCS file: {str(e)}"
+        raise ValueError(f"Error processing FCS file: {e}") from e
 
 
 def transform_key(key):

--- a/fcs_parser/tasks.py
+++ b/fcs_parser/tasks.py
@@ -1,111 +1,75 @@
+from __future__ import annotations
+
+import logging
 import os
 import traceback
 from datetime import timedelta
+
+import pandas as pd
 from celery import shared_task
-from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-import shutil
-import pandas as pd
-from .models import FileModel, ExperimentModel, FileDataModel, parquet_storage_dir
-from .services import decompres_file, process_fcs_file
-import zipfile
+
+from .models import ExperimentModel, FileDataModel, FileModel, parquet_storage_dir
+
+logger = logging.getLogger(__name__)
+
 
 @shared_task
 def process_experiment_files_task(file_id: int):
+    """Process FCS files asynchronously for a given FileModel.
+
+    Delegates entirely to the unified service
+    :func:`fcs_parser.services.process_experiment_zip`.
     """
-    Processa arquivos FCS de forma assíncrona para um dado FileModel.
-    Descomprime o arquivo, lê os FCS individuais, cria FileDataModel e atualiza o Experiment.
-    """
+    from fcs_parser.services.process_experiment_file import process_experiment_zip
+
+    file_model: FileModel | None = None
+    experiment: ExperimentModel | None = None
+
     try:
-        
-        file = get_object_or_404(FileModel, id=file_id)
-        experiment = file.experiment
-        experiment = file.experiment
-        if experiment.status != 'processing':
-            experiment.status = 'processing'
-            experiment.save()
-            directory_path = os.path.join(settings.MEDIA_ROOT, "fcs_files", str(experiment.id))
-            file_path = file.file.path
-            os.makedirs(directory_path, exist_ok=True)
-            with zipfile.ZipFile(file_path, "r") as zip_ref:
-                zip_ref.extractall(directory_path)
-            values = []
-            # Pasta persistente onde guardamos os .fcs originais (fonte da verdade).
-            fcs_source_dir = os.path.join(
-                settings.MEDIA_ROOT, "fcs_source", str(experiment.id)
+        file_model = get_object_or_404(FileModel, id=file_id)
+        experiment = file_model.experiment
+
+        if experiment.status == "processing":
+            logger.info(
+                "Experimento %s já está em processamento, ignorando.", experiment.id
             )
-            os.makedirs(fcs_source_dir, exist_ok=True)
-            try:
-                for root, dirs, files in os.walk(directory_path): 
-                    for file_name in files:
-                        if file_name.endswith(".fcs"):
-                            complete_path: str = os.path.join(root, file_name)
-                            processed_file = process_fcs_file(complete_path)
-                            if isinstance(processed_file, str):
-                                raise ValueError(processed_file)
-                            if len(values) == 0:
-                                values = processed_file[2]
-                            # Mantem o .fcs original como fonte (permite reprocessar).
-                            persistent_fcs = os.path.join(fcs_source_dir, file_name)
-                            shutil.copy2(complete_path, persistent_fcs)
-                            file_data_model = FileDataModel.objects.create(
-                                headers=processed_file[0],
-                                data_set=None,
-                                experiment=experiment,
-                                file_name=file_name,
-                                file=file,
-                                fcs_path=persistent_fcs,
-                            )
-                            # Grava o parseado em Parquet (cache morno) em vez de JSON.
-                            file_data_model.save_dataframe(
-                                pd.DataFrame(processed_file[1])
-                            )
-                experiment.values = values
-                experiment.status = 'done'
-                experiment.save()
-                print(f"SUCCESS: Processamento do Experimento {experiment.id} ('{experiment.title}') concluído.")
-                if os.path.exists(directory_path):
-                    shutil.rmtree(directory_path)
-                    print(f"INFO: Diretório temporário '{directory_path}' removido.")
-                
-                if os.path.exists(file_path):
-                    os.remove(file_path)
-                    print(f"INFO: Arquivo compactado original '{file_path}' removido.")
-            except Exception as e:
-                error_info = {
-                    'error_message': str(e),
-                    'details': traceback.format_exc()
-                }
-                experiment.status = 'error'
-                experiment.error_info = error_info
-                experiment.save()
-        
+            return
+
+        experiment.status = "processing"
+        experiment.save(update_fields=["status"])
+
+        process_experiment_zip(file_model)
+
     except Exception as e:
-
-        experiment = ExperimentModel.objects.get(id=experiment.id) 
-      
-
-        error_info = {
-            'error_message': str(e),
-            'details': traceback.format_exc() 
-        }
-        experiment.status = 'error'
-        experiment.error_info = error_info
-        experiment.save(update_fields=['status', 'error_info'])
-        print(f"ERROR: Erro durante o processamento do Experimento {experiment.id}: {e}\n{traceback.format_exc()}")
+        logger.error(
+            "Erro durante processamento do Experimento %s: %s",
+            experiment.id if experiment else "?",
+            e,
+            exc_info=True,
+        )
+        if experiment is not None:
+            experiment.refresh_from_db()
+            experiment.status = "error"
+            experiment.error_info = {
+                "error_message": str(e),
+                "details": traceback.format_exc(),
+            }
+            experiment.save(update_fields=["status", "error_info"])
 
 
 @shared_task
 def cleanup_cold_parquet_task(max_idle_days: int = 7):
-    """Limpa Parquet regeneravel: orfaos (sem linha no banco) e frios (sem acesso
-    ha mais de ``max_idle_days`` dias). Como o .fcs original e a fonte da verdade,
-    o Parquet some sem perda: o proximo ``get_dataframe`` o reconstroi.
+    """Remove regenerable Parquet files: orphans and cold (idle > max_idle_days).
+
+    The ZIP is the source of truth, so Parquet can always be rebuilt via
+    ``get_dataframe`` → re-extract from ZIP → reparse.
     """
     removed = 0
     parquet_dir = parquet_storage_dir()
 
-    # 1) Orfaos: arquivos .parquet no disco que nenhuma linha referencia.
+    # 1) Orphans: .parquet files on disk not referenced by any row.
     if os.path.isdir(parquet_dir):
         referenced = set(
             FileDataModel.objects.exclude(parquet_path__isnull=True)
@@ -121,13 +85,19 @@ def cleanup_cold_parquet_task(max_idle_days: int = 7):
                 except OSError:
                     pass
 
-    # 2) Frios: linhas cujo Parquet nao e acessado ha muito tempo e que tem .fcs
-    #    para reconstruir depois.
+    # 2) Cold: rows whose Parquet hasn't been accessed in a while
+    #    and whose experiment has a ZIP to rebuild from.
     cutoff = timezone.now() - timedelta(days=max_idle_days)
-    cold = FileDataModel.objects.exclude(parquet_path__isnull=True).exclude(
-        parquet_path=""
-    ).filter(last_accessed__lt=cutoff, fcs_path__isnull=False)
+    cold = (
+        FileDataModel.objects.exclude(parquet_path__isnull=True)
+        .exclude(parquet_path="")
+        .filter(last_accessed__lt=cutoff)
+        .select_related("experiment")
+    )
     for file_data in cold:
+        # Only remove if the experiment has a ZIP to rebuild from.
+        if not getattr(file_data.experiment, "zip_path", None):
+            continue
         path = file_data.parquet_path
         if path and os.path.exists(path):
             try:
@@ -137,41 +107,77 @@ def cleanup_cold_parquet_task(max_idle_days: int = 7):
                 continue
         FileDataModel.objects.filter(pk=file_data.pk).update(parquet_path=None)
 
-    print(f"INFO: cleanup_cold_parquet_task removeu {removed} arquivo(s) Parquet.")
+    logger.info("cleanup_cold_parquet_task removeu %d arquivo(s) Parquet.", removed)
     return removed
 
 
 @shared_task
 def recompute_file_data_task(file_data_id: int):
-    """Plano D: regenera o cache (Parquet) a partir do .fcs original (fonte) e
-    invalida a density no Redis, alem de recalcular os gates do arquivo.
+    """Regenerate Parquet cache from the experiment's ZIP (source of truth).
 
-    Fecha o ciclo "receita reconstroi tudo": .fcs (L0) + gates (L1) -> L2/L3.
+    Extracts the specific .fcs from the ZIP, reparses it, saves as Parquet,
+    invalidates Redis density cache, and recalculates gate analysis.
     """
     from analytics.models import GateModel
     from analytics.tasks import recalculate_gate_analysis_task
+    from fcs_parser.services.process_experiment_file import extract_fcs_from_zip
+    from fcs_parser.services.process_fcs import process_fcs_file
     from utils.density import invalidate_density
 
     file_data = get_object_or_404(FileDataModel, id=file_data_id)
+    experiment = file_data.experiment
 
-    if not (file_data.fcs_path and os.path.exists(file_data.fcs_path)):
-        print(
-            f"WARN: recompute_file_data_task: .fcs ausente para FileData {file_data_id}."
+    # Try to extract the .fcs from the ZIP (source of truth).
+    fcs_path = extract_fcs_from_zip(experiment, file_data.file_name)
+    if fcs_path is None:
+        logger.warning(
+            "recompute_file_data_task: não foi possível extrair '%s' do ZIP "
+            "para FileData %s.",
+            file_data.file_name,
+            file_data_id,
         )
-        return {"status": "skipped", "reason": "fcs_not_found"}
+        return {"status": "skipped", "reason": "fcs_not_found_in_zip"}
 
-    processed = process_fcs_file(file_data.fcs_path)
-    if isinstance(processed, str):
-        raise ValueError(processed)
+    try:
+        result = process_fcs_file(fcs_path)
+        file_data.save_dataframe(pd.DataFrame(result.data))
+    finally:
+        # Clean up the ephemeral extracted file.
+        if os.path.exists(fcs_path):
+            os.remove(fcs_path)
 
-    file_data.save_dataframe(pd.DataFrame(processed[1]))
-
-    # Invalida heatmaps/stats no Redis (bump de versao) e refaz analise dos gates.
     invalidate_density(file_data_id)
     for gate_id in GateModel.objects.filter(file_data_id=file_data_id).values_list(
         "id", flat=True
     ):
         recalculate_gate_analysis_task.delay(gate_id)
 
-    print(f"INFO: recompute_file_data_task regenerou FileData {file_data_id}.")
+    logger.info("recompute_file_data_task regenerou FileData %s.", file_data_id)
     return {"status": "ok", "file_data_id": file_data_id}
+
+
+@shared_task
+def cleanup_ephemeral_fcs_task():
+    """Remove leftover extraction directories (fcs_files/).
+
+    These are normally cleaned up by ``process_experiment_zip``, but may
+    linger after crashes or interrupted processing.
+    """
+    import shutil
+
+    fcs_root = os.path.join(settings.MEDIA_ROOT, "fcs_files")
+    if not os.path.isdir(fcs_root):
+        return 0
+
+    removed = 0
+    for name in os.listdir(fcs_root):
+        full = os.path.join(fcs_root, name)
+        if os.path.isdir(full):
+            try:
+                shutil.rmtree(full)
+                removed += 1
+            except OSError:
+                pass
+
+    logger.info("cleanup_ephemeral_fcs_task removeu %d diretório(s).", removed)
+    return removed

--- a/fcs_parser/views.py
+++ b/fcs_parser/views.py
@@ -1,12 +1,8 @@
 import json
 import os
-import shutil
-import traceback
+
 from django.conf import settings
-import pandas as pd
-from pathlib import Path
 from django.shortcuts import get_object_or_404
-from django.views.decorators.csrf import csrf_exempt
 from analytics.models import GateModel
 from fcs_parser.tasks import process_experiment_files_task, recompute_file_data_task
 from drf_spectacular.utils import extend_schema, inline_serializer, OpenApiParameter
@@ -32,14 +28,9 @@ from fcs_parser.serializers import (
     ExperimentSerializer,
     ListExperimentSerializer,
     ListFileDataSerializer,
-
     ParamListDataSerializer,
 )
-from django.forms.models import model_to_dict
-
-from fcs_parser.services.decompressor import decompres_file
-from fcs_parser.services.process_fcs import process_fcs_file
-from utils.mixins import SerializerByMethodMixin
+from fcs_parser.services.process_experiment_file import assemble_chunks
 
 
 class ExperimentInitView(generics.CreateAPIView):
@@ -60,7 +51,7 @@ class ExperimentInitView(generics.CreateAPIView):
     def post(self, request):
         title = request.data.get("title").replace(" ", "_")
         experiment_type = request.data.get("type")
-        total=request.data.get("totalChunks")
+        total = request.data.get("totalChunks")
         experiment = ExperimentModel.objects.create(
             title=title,
             type=experiment_type,
@@ -69,6 +60,7 @@ class ExperimentInitView(generics.CreateAPIView):
             total_chunks=total,
         )
         return Response({"fileId": str(experiment.id)}, status=201)
+
 
 class UploadChunkView(generics.CreateAPIView):
     @extend_schema(
@@ -92,21 +84,20 @@ class UploadChunkView(generics.CreateAPIView):
 
         experiment = ExperimentModel.objects.get(id=file_id)
 
-        # salva em disco
-        upload_dir = Path("/tmp/uploads")
-        upload_dir.mkdir(parents=True, exist_ok=True)
-        chunk_path = upload_dir / f"{file_id}_{chunk_index}.part"
+        chunk_dir = os.path.join(settings.MEDIA_ROOT, "chunks")
+        os.makedirs(chunk_dir, exist_ok=True)
+        chunk_path = os.path.join(chunk_dir, f"{file_id}_{chunk_index}.part")
         with open(chunk_path, "wb") as f:
             for c in chunk.chunks():
                 f.write(c)
 
-        # atualiza progresso
         if chunk_index not in experiment.received_chunks:
             experiment.received_chunks.append(chunk_index)
             experiment.save(update_fields=["received_chunks"])
 
         return Response({"status": "ok"})
-    
+
+
 class ExperimentCompleteView(generics.CreateAPIView):
     @extend_schema(
         request=inline_serializer(
@@ -122,36 +113,24 @@ class ExperimentCompleteView(generics.CreateAPIView):
         file_id = request.data["fileId"]
         experiment = ExperimentModel.objects.get(id=file_id)
 
-        upload_dir = Path("/tmp/uploads")
+        final_path = assemble_chunks(experiment)
         final_name = f"{file_id}.zip"
-        final_path = Path(settings.MEDIA_ROOT) / final_name
-
-        with open(final_path, "wb") as outfile:
-            for i in range(experiment.total_chunks):
-                chunk_path = upload_dir / f"{file_id}_{i}.part"
-                if not chunk_path.exists():
-                    raise ValueError(f"Chunk {i} faltando")
-                with open(chunk_path, "rb") as f:
-                    outfile.write(f.read())
-                os.remove(chunk_path)
 
         experiment.file_status = "uploaded"
         experiment.status = "new"
         experiment.save(update_fields=["file_status", "status"])
 
-        # cria o FileModel apontando para o zip final
         file_instance = FileModel.objects.create(
-            file=str(final_path),   # ou usar um campo FileField com upload_to
+            file=final_path,
             file_name=final_name,
-            experiment=experiment
+            experiment=experiment,
         )
 
-        # dispara task assíncrona com apenas o file_id
         process_experiment_files_task.delay(file_instance.id)
 
         return Response({"status": "processing"})
 
-    
+
 class ExperimentListView(generics.ListAPIView):
     serializer_class = ListExperimentSerializer
     queryset = ExperimentModel.objects.all()
@@ -168,7 +147,7 @@ class ExperimentListView(generics.ListAPIView):
     #             )
     #             file_instance = FileModel.objects.create(
     #                 file=file, file_name=file.name, experiment=experiment_instance
-    #             ) 
+    #             )
     #             process_experiment_files_task.delay(file_instance.id)
     #             return Response(
     #                 model_to_dict(experiment_instance), status=status.HTTP_201_CREATED
@@ -197,6 +176,7 @@ class GetExperimentFiles(generics.ListAPIView):
         experiment_id = self.kwargs.get("experiment_id")
         queryset = FileDataModel.objects.filter(experiment_id=experiment_id)
         return queryset
+
     def list(self, request, *args, **kwargs):
         # Retrieve the queryset of files
         queryset = self.get_queryset()
@@ -212,10 +192,11 @@ class GetExperimentFiles(generics.ListAPIView):
             gate_tree = GateModel.build_tree(file_data_id=file.id)
 
             # Add the built tree to the file data
-            file_data['gates'] = gate_tree
+            file_data["gates"] = gate_tree
             data.append(file_data)
-        
+
         return Response(data)
+
 
 class ListFileParams(generics.ListAPIView):
     lookup_field = "file_id"
@@ -234,10 +215,7 @@ class ListFileParams(generics.ListAPIView):
             limit = 10000
 
         file_data = self.get_queryset()
-        dataset = file_data.get_dataframe()
-        dataset.columns = dataset.columns.str.replace(" ", "")
-        dataset.columns = dataset.columns.str.replace("-", "_")
-        dataset.columns = dataset.columns.str.lower()
+        dataset = normalize_columns(file_data.get_dataframe())
         dataset = dataset.head(limit)
         file_data.data_set = json.loads(dataset.to_json(orient="records"))
         serializer = self.serializer_class(file_data)
@@ -249,19 +227,84 @@ class FileDensityView(APIView):
 
     @extend_schema(
         parameters=[
-            OpenApiParameter(name="x", type=str, required=True, description="X-axis parameter (e.g. FSC-A)"),
-            OpenApiParameter(name="y", type=str, required=True, description="Y-axis parameter (e.g. SSC-A)"),
-            OpenApiParameter(name="mode", type=str, required=False, description="'heatmap' (default) or 'scatter'"),
-            OpenApiParameter(name="bins", type=int, required=False, description="Bins for heatmap (default 200)"),
-            OpenApiParameter(name="sample", type=int, required=False, description="Max points for scatter (default 5000)"),
-            OpenApiParameter(name="xscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
-            OpenApiParameter(name="yscale", type=str, required=False, description="'linear' or 'biex' (default: heuristic by channel)"),
-            OpenApiParameter(name="cofactor", type=float, required=False, description="arcsinh cofactor for biex (default 150)"),
-            OpenApiParameter(name="cutoff", type=int, required=False, description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)"),
-            OpenApiParameter(name="xmin", type=float, required=False, description="Lower bound for X axis (raw value)"),
-            OpenApiParameter(name="xmax", type=float, required=False, description="Upper bound for X axis (raw value)"),
-            OpenApiParameter(name="ymin", type=float, required=False, description="Lower bound for Y axis (raw value)"),
-            OpenApiParameter(name="ymax", type=float, required=False, description="Upper bound for Y axis (raw value)"),
+            OpenApiParameter(
+                name="x",
+                type=str,
+                required=True,
+                description="X-axis parameter (e.g. FSC-A)",
+            ),
+            OpenApiParameter(
+                name="y",
+                type=str,
+                required=True,
+                description="Y-axis parameter (e.g. SSC-A)",
+            ),
+            OpenApiParameter(
+                name="mode",
+                type=str,
+                required=False,
+                description="'heatmap' (default) or 'scatter'",
+            ),
+            OpenApiParameter(
+                name="bins",
+                type=int,
+                required=False,
+                description="Bins for heatmap (default 200)",
+            ),
+            OpenApiParameter(
+                name="sample",
+                type=int,
+                required=False,
+                description="Max points for scatter (default 5000)",
+            ),
+            OpenApiParameter(
+                name="xscale",
+                type=str,
+                required=False,
+                description="'linear' or 'biex' (default: heuristic by channel)",
+            ),
+            OpenApiParameter(
+                name="yscale",
+                type=str,
+                required=False,
+                description="'linear' or 'biex' (default: heuristic by channel)",
+            ),
+            OpenApiParameter(
+                name="cofactor",
+                type=float,
+                required=False,
+                description="arcsinh cofactor for biex (default 150)",
+            ),
+            OpenApiParameter(
+                name="cutoff",
+                type=int,
+                required=False,
+                description="Heatmap density cutoff: bins with count <= cutoff become null/transparent (default 0)",
+            ),
+            OpenApiParameter(
+                name="xmin",
+                type=float,
+                required=False,
+                description="Lower bound for X axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="xmax",
+                type=float,
+                required=False,
+                description="Upper bound for X axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="ymin",
+                type=float,
+                required=False,
+                description="Lower bound for Y axis (raw value)",
+            ),
+            OpenApiParameter(
+                name="ymax",
+                type=float,
+                required=False,
+                description="Upper bound for Y axis (raw value)",
+            ),
         ],
         responses=inline_serializer(
             name="FileDensityResponse",
@@ -290,8 +333,18 @@ class FileDensityView(APIView):
         y_range = parse_range(request.query_params, "ymin", "ymax")
 
         cache_key = density_cache_key(
-            "file", file_id, file_id, x_param, y_param, mode, bins, sample,
-            x_scale, y_scale, cofactor, cutoff,
+            "file",
+            file_id,
+            file_id,
+            x_param,
+            y_param,
+            mode,
+            bins,
+            sample,
+            x_scale,
+            y_scale,
+            cofactor,
+            cutoff,
         )
         if x_range:
             cache_key += f":xr{x_range[0]}:{x_range[1]}"
@@ -304,14 +357,42 @@ class FileDensityView(APIView):
         file_data = get_object_or_404(FileDataModel, id=file_id)
         dataset = normalize_columns(file_data.get_dataframe())
 
-        base = {"mode": mode, "total_events": len(dataset), "x_label": x_param, "y_label": y_param}
+        base = {
+            "mode": mode,
+            "total_events": len(dataset),
+            "x_label": x_param,
+            "y_label": y_param,
+        }
 
         if mode == "scatter":
-            result = subsample_scatter(dataset, x_param, y_param, sample, x_scale, y_scale, cofactor, x_range, y_range)
+            result = subsample_scatter(
+                dataset,
+                x_param,
+                y_param,
+                sample,
+                x_scale,
+                y_scale,
+                cofactor,
+                x_range,
+                y_range,
+            )
         elif mode == "histogram":
-            result = compute_histogram(dataset, x_param, bins, x_scale, cofactor, x_range)
+            result = compute_histogram(
+                dataset, x_param, bins, x_scale, cofactor, x_range
+            )
         else:
-            result = compute_density(dataset, x_param, y_param, bins, x_scale, y_scale, cofactor, cutoff, x_range, y_range)
+            result = compute_density(
+                dataset,
+                x_param,
+                y_param,
+                bins,
+                x_scale,
+                y_scale,
+                cofactor,
+                cutoff,
+                x_range,
+                y_range,
+            )
 
         if result is None:
             return Response(
@@ -334,60 +415,23 @@ class ProcessFileDataView(generics.CreateAPIView):
         ),
     )
     def post(self, request, *args, **kwargs):
-        file_id = kwargs.get('file_id')
+        file_id = kwargs.get("file_id")
         file = get_object_or_404(FileModel, id=file_id)
         experiment = file.experiment
-        if experiment.status != 'processing':
-            experiment.status = 'processing'
-            experiment.save()
-            directory_path = os.path.join(settings.MEDIA_ROOT, "fcs_files", file.file_name)
-            file_path = os.path.join(settings.MEDIA_ROOT, file.file_name)
-            os.makedirs(directory_path, exist_ok=True)
-            decompres_file(file_path, directory_path)
-            values = []
-            fcs_source_dir = os.path.join(
-                settings.MEDIA_ROOT, "fcs_source", str(experiment.id)
+        if experiment.status == "processing":
+            return Response(
+                {"message": "The file is still being processed."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-            os.makedirs(fcs_source_dir, exist_ok=True)
-            try:
-                for root, dirs, files in os.walk(directory_path): 
-                    for file_name in files:
-                        if file_name.endswith(".fcs"):
-                            complete_path: str = os.path.join(root, file_name)
-                            processed_file = process_fcs_file(complete_path)
-                            if isinstance(processed_file, str):
-                                raise ValueError(processed_file)
-                            if len(values) == 0:
-                                values = processed_file[2]
-                            persistent_fcs = os.path.join(fcs_source_dir, file_name)
-                            shutil.copy2(complete_path, persistent_fcs)
-                            file_data_model = FileDataModel.objects.create(
-                                headers=processed_file[0],
-                                data_set=None,
-                                experiment=experiment,
-                                file_name=file_name,
-                                file=file,
-                                fcs_path=persistent_fcs,
-                            )
-                            file_data_model.save_dataframe(
-                                pd.DataFrame(processed_file[1])
-                            )
-                experiment.values = values
-                experiment.status = 'done'
-                experiment.save()
 
-                return Response({"message": "File processing was successfull."}, status=status.HTTP_200_OK)
+        experiment.status = "processing"
+        experiment.save(update_fields=["status"])
 
-            except Exception as e:
-                error_info = {
-                    'error_message': str(e),
-                    'details': traceback.format_exc()
-                }
-                experiment.status = 'error'
-                experiment.error_info = error_info
-                experiment.save()
-        else:
-            return Response({"message": "The file is still being processed."}, status=status.HTTP_400_BAD_REQUEST)
+        process_experiment_files_task.delay(file.id)
+        return Response(
+            {"message": "File processing scheduled."},
+            status=status.HTTP_202_ACCEPTED,
+        )
 
 
 class FileStatsView(APIView):
@@ -447,10 +491,9 @@ class FileStatsView(APIView):
 
 
 class RecomputeFileDataView(APIView):
-    """Plano D: reprocessa um FileData a partir do .fcs original + gates.
+    """Reprocess a FileData from the experiment's ZIP (or legacy .fcs).
 
-    Dispara a regeneracao do Parquet (cache morno) e a invalidacao da density
-    no Redis de forma assincrona (Celery).
+    Dispatches Parquet regeneration and Redis density invalidation via Celery.
     """
 
     @extend_schema(
@@ -465,9 +508,11 @@ class RecomputeFileDataView(APIView):
     )
     def post(self, request, file_id):
         file_data = get_object_or_404(FileDataModel, id=file_id)
-        if not file_data.fcs_path:
+        has_zip = bool(getattr(file_data.experiment, "zip_path", None))
+        has_fcs = bool(file_data.fcs_path)
+        if not has_zip and not has_fcs:
             return Response(
-                {"detail": "Sem .fcs original armazenado para reprocessar este arquivo."},
+                {"detail": "Sem fonte (ZIP ou .fcs) para reprocessar este arquivo."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         recompute_file_data_task.delay(file_data.id)


### PR DESCRIPTION
## Summary

Refactor que muda a fonte da verdade do sistema de arquivos `.fcs` avulsos para o **ZIP original** do upload, unifica lógica duplicada em services, e melhora robustez/tipagem. Inclui README completo com documentação de arquitetura e guia de contribuição.

### ZIP como fonte da verdade (L0)

Novo campo `ExperimentModel.zip_path` — o ZIP do upload é preservado em vez de deletado. A cascata de `FileDataModel.get_dataframe()` agora é:

```
Parquet (L2, cache morno)
  → extract_fcs_from_zip(experiment, file_name)  # L0, fonte da verdade
    → fcs_path legado (backward compat)
      → data_set JSON legado
```

`extract_fcs_from_zip()` extrai seletivamente um único `.fcs` do ZIP via `ZipFile.extract(member)`, reparseia, regenera o Parquet, e limpa o `.fcs` temporário.

### Pipeline unificado

`process_experiment_zip(file_model)` é agora a **única implementação** do fluxo ZIP → extract → parse → `FileDataModel` + Parquet. Substitui 3 implementações duplicadas (task, view, service legado).

```python
# Antes: lógica duplicada em tasks.py, views.py e process_experiment_file.py
# Depois: tudo delega para:
def process_experiment_zip(file_model: FileModel) -> list[str]: ...
```

### `FCSResult` dataclass

```python
@dataclass
class FCSResult:
    headers: dict
    data: list
    channels: list

def process_fcs_file(path: str) -> FCSResult:  # raises ValueError
```

Elimina o antipadrão de retornar `list | str` — agora sempre retorna `FCSResult` ou levanta `ValueError`.

### Chunks persistentes

Upload chunks movidos de `/tmp/uploads` para `MEDIA_ROOT/chunks/` (volume Docker persistente).

### Cleanup tasks

- `cleanup_cold_parquet_task`: agora verifica `experiment.zip_path` antes de remover Parquet frio.
- `cleanup_ephemeral_fcs_task` (novo): limpa diretórios `fcs_files/` órfãos de crashes. Roda semanalmente via Celery Beat.

### README

Reescrito com seções de:
- Arquitetura (modelo de dados, storage em camadas, fluxo de upload, services, gates)
- Guia de contribuição (regras pra PR, onde colocar código, convenções, decisões arquiteturais, o que NÃO fazer)

### Outras melhorias

- `print()` → `logging` em todos os módulos
- Error handling robusto no `process_experiment_files_task`
- `__str__()` em todos os models
- Remoção de código morto (`is_valid()`, `GateSerializer` comentado, `normalize_columns` manual)
- Migration: `0006_experimentmodel_zip_path`


Link to Devin session: https://app.devin.ai/sessions/dc1d1a9bc73e47dab810fdb589de40bf
Requested by: @paulo-moro